### PR TITLE
Support decimals in bounds

### DIFF
--- a/lineal-viz/src/bounds.ts
+++ b/lineal-viz/src/bounds.ts
@@ -3,7 +3,8 @@ import { tracked } from '@glimmer/tracking';
 
 // Ranges and domains can be specified using an expression similar
 // to Rust's range expression. This validates the expression.
-const NUMERIC_RANGE_DSL = /^(\d+)?\.\.(\d+)?$/;
+const NUMBER_PATTERN = '[+-]?\\d+.?\\d*';
+const NUMERIC_RANGE_DSL = new RegExp(`^(${NUMBER_PATTERN})?\.\.(${NUMBER_PATTERN})?$`);
 
 export default class Bounds<T> {
   @tracked min: T | undefined;
@@ -18,8 +19,8 @@ export default class Bounds<T> {
     }
 
     const [minStr, maxStr] = input.split('..');
-    const min = minStr ? parseInt(minStr, 10) : undefined;
-    const max = maxStr ? parseInt(maxStr, 10) : undefined;
+    const min = minStr ? parseFloat(minStr) : undefined;
+    const max = maxStr ? parseFloat(maxStr) : undefined;
 
     return new Bounds<number>(min, max);
   }

--- a/test-app/tests/unit/bounds-test.ts
+++ b/test-app/tests/unit/bounds-test.ts
@@ -130,6 +130,26 @@ module('Unit | Bounds.parse', function () {
         name: 'when provided with an array, the same array is returned',
         input: [5, 10, 15],
       },
+      {
+        name: '"0.5..10.2" respects decimals and has 0.5 as min and 10.2 as max',
+        input: '0.5..10.2',
+        output: new Bounds(0.5, 10.2),
+      },
+      {
+        name: '"1.3.5..10.9" is bad input and throws',
+        input: '1.3.5..10.9',
+        output: null,
+      },
+      {
+        name: '"-3.14..3.14" respects the negative sign',
+        input: '-3.14..3.14',
+        output: new Bounds(-3.14, 3.14),
+      },
+      {
+        name: '"3.14..-3.14" respects the negative sign',
+        input: '3.14..-3.14',
+        output: new Bounds(3.14, -3.14),
+      },
     ],
     1,
     function (t, assert) {


### PR DESCRIPTION
The first bug fixed in its very own PR 🥲 

It used to be that bounds were parsed using `parseInt` instead of `parseFloat`, which meant the very valid code:

```js
Bounds.parse('0.5..10.2')
```

Wouldn't work. It would instead return bounds equivalent of `[0, 10]`.

While updating the regex to allow for decimals, I also caught that it didn't support negative signs, so I got that in there too.