### PR TITLE
Axes and Gridlines

### DIFF
--- a/lineal-viz/package.json
+++ b/lineal-viz/package.json
@@ -68,6 +68,7 @@
       "./components/lineal/arc/index.js": "./dist/_app_/components/lineal/arc/index.js",
       "./components/lineal/arcs/index.js": "./dist/_app_/components/lineal/arcs/index.js",
       "./components/lineal/area/index.js": "./dist/_app_/components/lineal/area/index.js",
+      "./components/lineal/axis/index.js": "./dist/_app_/components/lineal/axis/index.js",
       "./components/lineal/line/index.js": "./dist/_app_/components/lineal/line/index.js",
       "./helpers/css-range.js": "./dist/_app_/helpers/css-range.js",
       "./helpers/scale-diverging-log.js": "./dist/_app_/helpers/scale-diverging-log.js",

--- a/lineal-viz/package.json
+++ b/lineal-viz/package.json
@@ -69,6 +69,7 @@
       "./components/lineal/arcs/index.js": "./dist/_app_/components/lineal/arcs/index.js",
       "./components/lineal/area/index.js": "./dist/_app_/components/lineal/area/index.js",
       "./components/lineal/axis/index.js": "./dist/_app_/components/lineal/axis/index.js",
+      "./components/lineal/gridlines/index.js": "./dist/_app_/components/lineal/gridlines/index.js",
       "./components/lineal/line/index.js": "./dist/_app_/components/lineal/line/index.js",
       "./helpers/css-range.js": "./dist/_app_/helpers/css-range.js",
       "./helpers/scale-diverging-log.js": "./dist/_app_/helpers/scale-diverging-log.js",

--- a/lineal-viz/src/components/lineal/axis/index.hbs
+++ b/lineal-viz/src/components/lineal/axis/index.hbs
@@ -1,5 +1,7 @@
 <g class='axis' ...attributes>
-  <path class='domain' stroke='currentColor' d={{this.domainPath}}></path>
+  {{#if this.includeDomain}}
+    <path class='domain' stroke='currentColor' d={{this.domainPath}}></path>
+  {{/if}}
   {{#if (eq this.direction 'horizontal')}}
     {{#each this.ticks as |tick|}}
       <g transform={{tick.transform}}>

--- a/lineal-viz/src/components/lineal/axis/index.hbs
+++ b/lineal-viz/src/components/lineal/axis/index.hbs
@@ -1,0 +1,11 @@
+<g class='axis' ...attributes>
+  <path class='domain' stroke='currentColor' d={{this.domainPath}}></path>
+  {{#each this.ticks as |tick|}}
+    <g transform={{tick.transform}}>
+      <line stroke='currentColor' y2={{tick.size}}></line>
+      {{#if tick.label}}
+        <text fill='currentColor' y2={{tick.offset}}>{{tick.label}}</text>
+      {{/if}}
+    </g>
+  {{/each}}
+</g>

--- a/lineal-viz/src/components/lineal/axis/index.hbs
+++ b/lineal-viz/src/components/lineal/axis/index.hbs
@@ -1,11 +1,32 @@
 <g class='axis' ...attributes>
   <path class='domain' stroke='currentColor' d={{this.domainPath}}></path>
-  {{#each this.ticks as |tick|}}
-    <g transform={{tick.transform}}>
-      <line stroke='currentColor' y2={{tick.size}}></line>
-      {{#if tick.label}}
-        <text fill='currentColor' y2={{tick.offset}}>{{tick.label}}</text>
-      {{/if}}
-    </g>
-  {{/each}}
+  {{#if (eq this.direction 'horizontal')}}
+    {{#each this.ticks as |tick|}}
+      <g transform={{tick.transform}}>
+        <line stroke='currentColor' y2={{tick.size}}></line>
+        {{#if tick.label}}
+          <text
+            fill='currentColor'
+            y={{tick.offset}}
+            dy={{tick.textOffset}}
+            text-anchor={{tick.textAnchor}}
+          >{{tick.label}}</text>
+        {{/if}}
+      </g>
+    {{/each}}
+  {{else}}
+    {{#each this.ticks as |tick|}}
+      <g transform={{tick.transform}}>
+        <line stroke='currentColor' x2={{tick.size}}></line>
+        {{#if tick.label}}
+          <text
+            fill='currentColor'
+            x={{tick.offset}}
+            dy={{tick.textOffset}}
+            text-anchor={{tick.textAnchor}}
+          >{{tick.label}}</text>
+        {{/if}}
+      </g>
+    {{/each}}
+  {{/if}}
 </g>

--- a/lineal-viz/src/components/lineal/axis/index.ts
+++ b/lineal-viz/src/components/lineal/axis/index.ts
@@ -1,0 +1,114 @@
+import { scheduleOnce } from '@ember/runloop';
+import Component from '@glimmer/component';
+import { tracked, cached } from '@glimmer/tracking';
+import { extent } from 'd3-array';
+import { Scale } from '../../../scale';
+import Bounds from '../../../bounds';
+
+enum Orientation {
+  Top = 'top',
+  Right = 'right',
+  Bottom = 'bottom',
+  Left = 'left',
+}
+
+enum OrientationInt {
+  Top = 1,
+  Right = 2,
+  Bottom = 3,
+  Left = 4,
+}
+
+enum Direction {
+  Vertical = 'vertical',
+  Horizontal = 'horizontal',
+}
+
+interface AreaArgs {
+  scale: Scale;
+  orientation: Orientation;
+  tickValues?: any[];
+  tickFormat?: (t: any) => string;
+  tickSize?: number;
+  tickSizeInner?: number;
+  tickSizeOuter?: number;
+  tickPadding?: number;
+  offset?: number;
+}
+
+const DEFAULT_OFFSET = typeof window !== 'undefined' && window.devicePixelRatio > 1 ? 0 : 0.5;
+
+export default class Area extends Component<AreaArgs> {
+  @tracked tickValues = this.args.tickValues || null;
+  @tracked tickFormat = this.args.tickFormat || null;
+  @tracked tickSizeInner = this.args.tickSizeInner || 6;
+  @tracked tickSizeOuter = this.args.tickSizeOuter || 6;
+  @tracked tickPadding = this.args.tickPadding || 3;
+  @tracked offset = this.args.offset || DEFAULT_OFFSET;
+
+  tickArguments = [];
+
+  @cached get orientation(): OrientationInt {
+    const mapping = {
+      [Orientation.Top]: OrientationInt.Top,
+      [Orientation.Right]: OrientationInt.Right,
+      [Orientation.Bottom]: OrientationInt.Bottom,
+      [Orientation.Left]: OrientationInt.Left,
+    };
+
+    return mapping[this.args.orientation];
+  }
+
+  @cached get direction(): Direction {
+    return this.orientation === OrientationInt.Left || this.orientation === OrientationInt.Right
+      ? Direction.Vertical
+      : Direction.Horizontal;
+  }
+
+  @cached get domainPath(): string {
+    const { tickSizeOuter, offset } = this;
+    const orientation = this.orientation;
+    const range = this.args.scale.d3Scale.range();
+
+    const range0 = range[0] + offset;
+    const range1 = range[range.length - 1] + offset;
+    const k = orientation === OrientationInt.Top || orientation === OrientationInt.Left ? -1 : 1;
+
+    if (this.direction === Direction.Vertical) {
+      return tickSizeOuter !== 0
+        ? `M${k * tickSizeOuter},${range0}H${offset}V${range1}H${k * tickSizeOuter}`
+        : `M${offset},${range0}V${range1}`;
+    }
+    return tickSizeOuter !== 0
+      ? `M${range0},${k * tickSizeOuter}V${offset}H${range1}V${k * tickSizeOuter}`
+      : `M${range0},${offset}H${range1}`;
+  }
+
+  @cached get values() {
+    // 1. If tickValues, return tickValues
+    // 2. If tickArguments, return scale.ticks.apply(scale, tickArguments) (can we do better than this?)
+    // 3. If scale.ticks, return scale.ticks()
+    // 4. Return scale.domain()
+    if (this.tickValues) return this.tickValues;
+    if (this.args.scale.d3Scale.ticks) return this.args.scale.d3Scale.ticks();
+    return this.args.scale.d3Scale.domain();
+  }
+
+  @cached get format() {
+    // 1. If tickFormat, return tickFormat
+    // 2. If tickArguments, return scale.tickFormat.apply(scale, tickArguments)
+    // 3. If scale.tickFormat, return scale.tickFormat()
+    // 4. Return identity function x => x
+    if (this.tickFormat) return this.tickFormat;
+    if (this.args.scale.d3Scale.tickFormat) return this.args.scale.d3Scale.tickFormat;
+    return (x: any) => x;
+  }
+
+  @cached get spacing() {
+    return Math.max(this.tickSizeInner, 0) + this.tickPadding;
+  }
+
+  @cached get ticks() {
+    return [];
+  }
+}

--- a/lineal-viz/src/components/lineal/axis/index.ts
+++ b/lineal-viz/src/components/lineal/axis/index.ts
@@ -31,6 +31,7 @@ interface AxisArgs {
   tickSizeOuter?: number;
   tickPadding?: number;
   offset?: number;
+  includeDomain?: boolean;
 }
 
 const DEFAULT_OFFSET = typeof window !== 'undefined' && window.devicePixelRatio > 1 ? 0 : 0.5;
@@ -48,14 +49,18 @@ const TEXT_ANCHOR = {
 };
 
 export default class Axis extends Component<AxisArgs> {
-  @tracked tickValues = this.args.tickValues || null;
-  @tracked tickFormat = this.args.tickFormat || null;
-  @tracked tickSizeInner = this.args.tickSizeInner || 6;
-  @tracked tickSizeOuter = this.args.tickSizeOuter || 6;
-  @tracked tickPadding = this.args.tickPadding || 3;
-  @tracked offset = this.args.offset || DEFAULT_OFFSET;
+  @tracked tickValues = this.args.tickValues ?? null;
+  @tracked tickFormat = this.args.tickFormat ?? null;
+  @tracked tickSizeInner = this.args.tickSizeInner ?? this.args.tickSize ?? 6;
+  @tracked tickSizeOuter = this.args.tickSizeOuter ?? this.args.tickSize ?? 6;
+  @tracked tickPadding = this.args.tickPadding ?? 3;
+  @tracked offset = this.args.offset ?? DEFAULT_OFFSET;
 
   tickArguments = [];
+
+  get includeDomain() {
+    return this.args.includeDomain ?? true;
+  }
 
   @cached get orientation(): OrientationInt {
     const mapping = {

--- a/lineal-viz/src/components/lineal/axis/index.ts
+++ b/lineal-viz/src/components/lineal/axis/index.ts
@@ -49,14 +49,32 @@ const TEXT_ANCHOR = {
 };
 
 export default class Axis extends Component<AxisArgs> {
-  @tracked tickValues = this.args.tickValues ?? null;
-  @tracked tickFormat = this.args.tickFormat ?? null;
-  @tracked tickSizeInner = this.args.tickSizeInner ?? this.args.tickSize ?? 6;
-  @tracked tickSizeOuter = this.args.tickSizeOuter ?? this.args.tickSize ?? 6;
-  @tracked tickPadding = this.args.tickPadding ?? 3;
-  @tracked offset = this.args.offset ?? DEFAULT_OFFSET;
+  // TODO: Implement tickArguments for d3-axis parity, but maybe not the same signature.
+  //tickArguments = [];
 
-  tickArguments = [];
+  @cached get tickValues() {
+    return this.args.tickValues ?? null;
+  }
+
+  @cached get tickFormat() {
+    return this.args.tickFormat ?? null;
+  }
+
+  @cached get tickSizeInner() {
+    return this.args.tickSizeInner ?? this.args.tickSize ?? 6;
+  }
+
+  @cached get tickSizeOuter() {
+    return this.args.tickSizeOuter ?? this.args.tickSize ?? 6;
+  }
+
+  @cached get tickPadding() {
+    return this.args.tickPadding ?? 3;
+  }
+
+  @cached get offset() {
+    return this.args.offset ?? DEFAULT_OFFSET;
+  }
 
   get includeDomain() {
     return this.args.includeDomain ?? true;

--- a/lineal-viz/src/components/lineal/axis/index.ts
+++ b/lineal-viz/src/components/lineal/axis/index.ts
@@ -21,7 +21,7 @@ enum Direction {
   Horizontal = 'horizontal',
 }
 
-interface AreaArgs {
+interface AxisArgs {
   scale: Scale;
   orientation: Orientation;
   tickValues?: any[];
@@ -47,7 +47,7 @@ const TEXT_ANCHOR = {
   [OrientationInt.Left]: 'end',
 };
 
-export default class Area extends Component<AreaArgs> {
+export default class Axis extends Component<AxisArgs> {
   @tracked tickValues = this.args.tickValues || null;
   @tracked tickFormat = this.args.tickFormat || null;
   @tracked tickSizeInner = this.args.tickSizeInner || 6;

--- a/lineal-viz/src/components/lineal/gridlines/index.hbs
+++ b/lineal-viz/src/components/lineal/gridlines/index.hbs
@@ -1,0 +1,12 @@
+<g class='gridlines'>
+  {{#each this.lines as |l|}}
+    <line
+      stroke='currentColor'
+      x1={{l.x1}}
+      x2={{l.x2}}
+      y1={{l.y1}}
+      y2={{l.y2}}
+      ...attributes
+    ></line>
+  {{/each}}
+</g>

--- a/lineal-viz/src/components/lineal/gridlines/index.ts
+++ b/lineal-viz/src/components/lineal/gridlines/index.ts
@@ -1,0 +1,52 @@
+import Component from '@glimmer/component';
+import { tracked, cached } from '@glimmer/tracking';
+import { Scale } from '../../../scale';
+
+enum Direction {
+  Vertical = 'vertical',
+  Horizontal = 'horizontal',
+}
+
+interface GridlinesArgs {
+  scale: Scale;
+  direction: Direction;
+  length: number;
+  lineValues?: any[];
+  offset?: number;
+}
+
+const DEFAULT_OFFSET = typeof window !== 'undefined' && window.devicePixelRatio > 1 ? 0 : 0.5;
+
+export default class Gridlines extends Component<GridlinesArgs> {
+  @tracked lineValues = this.args.lineValues || null;
+  @tracked offset = this.args.offset || DEFAULT_OFFSET;
+
+  @cached get values() {
+    if (this.lineValues) return this.lineValues;
+    if (this.args.scale.d3Scale.ticks) return this.args.scale.d3Scale.ticks();
+    return this.args.scale.d3Scale.domain();
+  }
+
+  @cached get position() {
+    const copy = this.args.scale.d3Scale.copy();
+    if (copy.bandwidth) {
+      let offset = Math.max(0, copy.bandwidth() - this.offset * 2) / 2;
+      if (copy.round()) offset = Math.round(offset);
+      return (d: number) => +copy(d) + offset;
+    }
+    return (d: number) => +copy(d);
+  }
+
+  @cached get lines() {
+    const { length, direction } = this.args;
+    const { offset, position } = this;
+    const isHorizontal = direction === Direction.Horizontal;
+
+    return this.values.map((v: any) => ({
+      x1: isHorizontal ? 0 : position(v) + offset,
+      x2: isHorizontal ? length : position(v) + offset,
+      y1: isHorizontal ? position(v) + offset : 0,
+      y2: isHorizontal ? position(v) + offset : length,
+    }));
+  }
+}

--- a/test-app/app/styles/app.css
+++ b/test-app/app/styles/app.css
@@ -18,3 +18,8 @@
 .no-overflow {
   overflow: visible;
 }
+
+.line-chart-example {
+  margin: 20px 100px;
+  overflow: visible;
+}

--- a/test-app/app/styles/app.css
+++ b/test-app/app/styles/app.css
@@ -10,3 +10,11 @@
 .reds-3 {
   fill: #6d360f;
 }
+
+.axis .domain {
+  fill: none;
+}
+
+.no-overflow {
+  overflow: visible;
+}

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -110,6 +110,21 @@
         @orientation='bottom'
         transform='translate(0,200)'
       />
+      <Lineal::Gridlines
+        @scale={{yScale}}
+        @lineValues={{array 20000000 100000000 200000000 280000000}}
+        @direction='horizontal'
+        @length={{800}}
+        stroke-dasharray='5 5'
+        opacity='0.7'
+      />
+      <Lineal::Gridlines
+        @scale={{xScale}}
+        @direction='vertical'
+        @length={{200}}
+        stroke-dasharray='5 5'
+        opacity='0.3'
+      />
       {{#each this.population as |d|}}
         <circle
           cx={{xScale.compute d.year}}

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -82,7 +82,7 @@
 </svg>
 
 <p>Line</p>
-<svg width='800' height='200' style='margin:20px 100px;overflow:visible'>
+<svg width='800' height='200'>
   {{#let
     (scale-linear range='0..800')
     (scale-linear range='200..0')

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -2,6 +2,22 @@
 
 <h2 id='title'>Welcome to Ember</h2>
 
+<p>Axes</p>
+{{#let (scale-pow range='15..785' domain='0..10' exponent='2') as |scale|}}
+  <svg class='no-overflow' width='800' height='30'>
+    <Lineal::Axis @scale={{scale}} @orientation='bottom' />
+  </svg>
+  <svg class='no-overflow' width='800' height='30'>
+    <Lineal::Axis @scale={{scale}} @orientation='top' />
+  </svg>
+  <svg class='no-overflow' width='100' height='300'>
+    <Lineal::Axis @scale={{scale}} @orientation='left' />
+  </svg>
+  <svg class='no-overflow' width='100' height='300'>
+    <Lineal::Axis @scale={{scale}} @orientation='right' />
+  </svg>
+{{/let}}
+
 <p>Scale Linear</p>
 <svg width='800' height='6'>
   {{#let (scale-linear range='15..785' domain='0..10') as |scale|}}
@@ -66,10 +82,10 @@
 </svg>
 
 <p>Line</p>
-<svg width='800' height='200'>
+<svg width='800' height='200' style='margin:20px 100px;overflow:visible'>
   {{#let
-    (scale-linear range='15..785')
-    (scale-linear range='190..10')
+    (scale-linear range='0..800')
+    (scale-linear range='200..0')
     as |xScale yScale|
   }}
     <Lineal::Line
@@ -78,12 +94,22 @@
       @yScale={{yScale}}
       @x='year'
       @y='people'
-      @curve='step'
+      @curve='natural'
       fill='transparent'
       stroke='black'
       stroke-width='2'
     />
     {{#if (and xScale.isValid yScale.isValid)}}
+      <Lineal::Axis
+        @scale={{yScale}}
+        @orientation='left'
+        @tickValues={{array 20000000 100000000 200000000 280000000}}
+      />
+      <Lineal::Axis
+        @scale={{xScale}}
+        @orientation='bottom'
+        transform='translate(0,200)'
+      />
       {{#each this.population as |d|}}
         <circle
           cx={{xScale.compute d.year}}

--- a/test-app/tests/integration/components/lineal/axis-test.ts
+++ b/test-app/tests/integration/components/lineal/axis-test.ts
@@ -16,7 +16,11 @@ function orientationTest(
 
     await render(hbs`
       <svg>
-        <Lineal::Axis @scale={{this.scale}} @orientation={{this.orientation}} @tickSize={{10}} />
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation={{this.orientation}}
+          @tickSize={{10}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -41,7 +45,7 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
 
     await render(hbs`
       <svg>
-        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" />
+        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @offset={{0}} />
       </svg>
     `);
 
@@ -102,7 +106,11 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
 
     await render(hbs`
       <svg>
-        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickValues={{this.tickValues}} />
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation="bottom"
+          @tickValues={{this.tickValues}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -125,7 +133,11 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
 
     await render(hbs`
       <svg>
-        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickFormat={{this.tickFormat}} />
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation="bottom"
+          @tickFormat={{this.tickFormat}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -142,7 +154,11 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
 
     await render(hbs`
       <svg>
-        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickFormat={{this.tickFormat}} />
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation="bottom"
+          @tickFormat={{this.tickFormat}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -161,7 +177,11 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
 
     await render(hbs`
       <svg>
-        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickSize={{this.tickSize}} />
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation="bottom"
+          @tickSize={{this.tickSize}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -187,7 +207,8 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
           @scale={{this.scale}}
           @orientation="bottom"
           @tickSize={{this.tickSize}}
-          @tickSizeInner={{this.tickSizeInner}} />
+          @tickSizeInner={{this.tickSizeInner}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -213,7 +234,8 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
           @scale={{this.scale}}
           @orientation="bottom"
           @tickSize={{this.tickSize}}
-          @tickSizeOuter={{this.tickSizeOuter}} />
+          @tickSizeOuter={{this.tickSizeOuter}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -240,7 +262,8 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
           @scale={{this.scale}}
           @orientation={{this.orientation}}
           @tickSize={{this.tickSize}}
-          @tickPadding={{this.tickPadding}} />
+          @tickPadding={{this.tickPadding}}
+          @offset={{0}} />
       </svg>
     `);
 
@@ -267,7 +290,7 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
 
     await render(hbs`
       <svg>
-        <Lineal::Axis @scale={{this.scale}} @includeDomain={{this.includeDomain}} />
+        <Lineal::Axis @scale={{this.scale}} @includeDomain={{this.includeDomain}} @offset={{0}} />
       </svg>
     `);
 

--- a/test-app/tests/integration/components/lineal/axis-test.ts
+++ b/test-app/tests/integration/components/lineal/axis-test.ts
@@ -1,0 +1,281 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, findAll, TestContext, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { Scale, ScaleLinear } from 'lineal-viz/scale';
+
+function orientationTest(
+  orientation: string,
+  lineAttr: string,
+  attrValue: string,
+  translateFn: (scale: Scale, value: number) => string
+) {
+  return async function (this: TestContext, assert: Assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    this.setProperties({ scale, orientation });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis @scale={{this.scale}} @orientation={{this.orientation}} @tickSize={{10}} />
+      </svg>
+    `);
+
+    assert.deepEqual(
+      findAll('.axis g').map((el) => el.getAttribute('transform')),
+      scale.d3Scale.ticks().map((t) => translateFn(scale, t))
+    );
+
+    assert.deepEqual(
+      findAll('.axis line').map((el) => el.getAttribute(lineAttr)),
+      Array(scale.d3Scale.ticks().length).fill(attrValue)
+    );
+  };
+}
+
+module('Integration | Component | Lineal::Axis', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Given a scale and an orientation, renders ticks and labels', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    this.setProperties({ scale });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" />
+      </svg>
+    `);
+
+    assert.strictEqual(
+      findAll('.axis text').length,
+      scale.d3Scale.ticks().length
+    );
+    assert.strictEqual(
+      findAll('.axis line').length,
+      scale.d3Scale.ticks().length
+    );
+  });
+
+  test(
+    'Axis can have an orientation of top',
+    orientationTest(
+      'top',
+      'y2',
+      '-10',
+      (s, t) => `translate(${s.compute(t)},0)`
+    )
+  );
+
+  test(
+    'Axis can have an orientation of right',
+    orientationTest(
+      'right',
+      'x2',
+      '10',
+      (s, t) => `translate(0,${s.compute(t)})`
+    )
+  );
+
+  test(
+    'Axis can have an orientation of bottom',
+    orientationTest(
+      'bottom',
+      'y2',
+      '10',
+      (s, t) => `translate(${s.compute(t)},0)`
+    )
+  );
+
+  test(
+    'Axis can have an orientation of left',
+    orientationTest(
+      'left',
+      'x2',
+      '-10',
+      (s, t) => `translate(0,${s.compute(t)})`
+    )
+  );
+
+  test('The tickValues arg is used to manually specify rendered ticks', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickValues = [0, 0.5, 1.5, 3, 5, 7.5];
+    this.setProperties({ scale, tickValues });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickValues={{this.tickValues}} />
+      </svg>
+    `);
+
+    assert.deepEqual(
+      findAll('.axis text').map((el) => el.textContent),
+      tickValues.map((t) => scale.d3Scale.tickFormat()(t))
+    );
+
+    assert.deepEqual(
+      findAll('.axis g').map((el) => el.getAttribute('transform')),
+      tickValues.map((t) => `translate(${scale.compute(t)},0)`)
+    );
+  });
+
+  test('The tickFormat arg is used to manually specify how tick labels are formatted', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickFormat = (t: number) =>
+      Math.round(t) % 2 === 0 ? 'even' : 'odd';
+    this.setProperties({ scale, tickFormat });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickFormat={{this.tickFormat}} />
+      </svg>
+    `);
+
+    assert.deepEqual(
+      findAll('.axis text').map((el) => el.textContent),
+      'even odd even odd even odd even odd even odd even'.split(' ')
+    );
+  });
+
+  test('When tickFormat returns a nullish value for a tick, a label is not rendered', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickFormat = (t: number) => Math.round(t) % 2 === 0 && '' + t;
+    this.setProperties({ scale, tickFormat });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickFormat={{this.tickFormat}} />
+      </svg>
+    `);
+
+    assert.strictEqual(findAll('.axis text').length, 6);
+    assert.strictEqual(findAll('.axis line').length, 11);
+    assert.deepEqual(
+      findAll('.axis text').map((el) => el.textContent),
+      ['0', '2', '4', '6', '8', '10']
+    );
+  });
+
+  test('tickSize controls both the inner ticks as well as the outer ticks', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickSize = 10;
+    this.setProperties({ scale, tickSize });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis @scale={{this.scale}} @orientation="bottom" @tickSize={{this.tickSize}} />
+      </svg>
+    `);
+
+    assert.deepEqual(
+      findAll('.axis line').map((el) => el.getAttribute('y2')),
+      Array(scale.d3Scale.ticks().length).fill(tickSize.toString())
+    );
+
+    assert
+      .dom('.axis .domain')
+      .hasAttribute('d', `M0,${tickSize}V0H100V${tickSize}`);
+  });
+
+  test('tickSizeInner overrides tickSize', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickSize = 10;
+    const tickSizeInner = 5;
+    this.setProperties({ scale, tickSize, tickSizeInner });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation="bottom"
+          @tickSize={{this.tickSize}}
+          @tickSizeInner={{this.tickSizeInner}} />
+      </svg>
+    `);
+
+    assert.deepEqual(
+      findAll('.axis line').map((el) => el.getAttribute('y2')),
+      Array(scale.d3Scale.ticks().length).fill(tickSizeInner.toString())
+    );
+
+    assert
+      .dom('.axis .domain')
+      .hasAttribute('d', `M0,${tickSize}V0H100V${tickSize}`);
+  });
+
+  test('tickSizeOuter overrides tickSize', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickSize = 10;
+    const tickSizeOuter = 5;
+    this.setProperties({ scale, tickSize, tickSizeOuter });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation="bottom"
+          @tickSize={{this.tickSize}}
+          @tickSizeOuter={{this.tickSizeOuter}} />
+      </svg>
+    `);
+
+    assert.deepEqual(
+      findAll('.axis line').map((el) => el.getAttribute('y2')),
+      Array(scale.d3Scale.ticks().length).fill(tickSize.toString())
+    );
+
+    assert
+      .dom('.axis .domain')
+      .hasAttribute('d', `M0,${tickSizeOuter}V0H100V${tickSizeOuter}`);
+  });
+
+  test('The tickPadding arg is used to specify the distance from tick marks and tick labels', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickSize = 10;
+    const tickPadding = 20;
+    const orientation = 'bottom';
+    this.setProperties({ scale, tickSize, tickPadding, orientation });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation={{this.orientation}}
+          @tickSize={{this.tickSize}}
+          @tickPadding={{this.tickPadding}} />
+      </svg>
+    `);
+
+    assert.deepEqual(
+      findAll('.axis text').map((el) => el.getAttribute('y')),
+      Array(scale.d3Scale.ticks().length).fill(tickSize + tickPadding + '')
+    );
+
+    this.set('orientation', 'left');
+    await settled();
+
+    assert.deepEqual(
+      findAll('.axis text').map((el) => el.getAttribute('x')),
+      Array(scale.d3Scale.ticks().length).fill(
+        -1 * (tickSize + tickPadding) + ''
+      )
+    );
+  });
+
+  test('When includeDomain is false, the domain is not rendered', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const includeDomain = true;
+    this.setProperties({ scale, includeDomain });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis @scale={{this.scale}} @includeDomain={{this.includeDomain}} />
+      </svg>
+    `);
+
+    assert.dom('.domain').exists();
+
+    this.set('includeDomain', false);
+    await settled();
+
+    assert.dom('.domain').doesNotExist();
+  });
+});

--- a/test-app/tests/integration/components/lineal/gridlines-test.ts
+++ b/test-app/tests/integration/components/lineal/gridlines-test.ts
@@ -1,0 +1,10 @@
+import { module, todo } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+module('Integration | Component | Lineal::Gridlines', function (hooks) {
+  setupRenderingTest(hooks);
+
+  todo('test coverage', function () {
+    // Test coverage is coming soon, but I want to get this in front of people ASAP
+  });
+});


### PR DESCRIPTION
This is a pure glimmer/tracked implementation of [d3-axis](https://github.com/d3/d3-axis) which isn't much more than some DOM rendering on top of data emitted by scales. 

Instead of using d3-selection and d3-transition, this using glimmer for data binding and....nothing yet for animations. That'll come later.

Conventionally, gridlines in d3 are implemented using d3-axis with some imperative post-processing done to hide/remove labels and the domain line. Since this is such a common pattern it's implemented here as its own component.

<img width="943" alt="image" src="https://user-images.githubusercontent.com/174740/189735715-d101de37-d2ea-49cd-b051-750c6f8108ff.png">
