### PR TITLE
Cached decorator compatibility 

### DIFF
--- a/.changeset/strange-pants-tell.md
+++ b/.changeset/strange-pants-tell.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Introduces a compatibility cached package for when cached is undefined downstream

--- a/lineal-viz/src/cached.ts
+++ b/lineal-viz/src/cached.ts
@@ -1,0 +1,19 @@
+import 'ember-cached-decorator-polyfill';
+import { cached as originalCached } from '@glimmer/tracking';
+
+/* This is a bit of a hack to guarantee that @cached is available throughout this addon
+ * regardless of how the consuming Ember app is building its dependencies. Right now it's
+ * possible in Ember 3.x without building with Embroider for cached from @glimmer/tracking
+ * to be undefined due to some babel shenanigans Ember uses for compatibility with non-module
+ * "modules", such as `@glimmer/tracking` which gets rewritten to import from Ember itself.
+ *
+ * The downside is that `noop` doesn't cache at all, it's just a passthrough decorator meant
+ * to maintain compatibility.
+ *
+ * Tracking issue: https://github.com/ef4/ember-auto-import/issues/536
+ */
+function noop(...args: any[]): void {
+  // noop, simple passthrough
+}
+
+export const cached = originalCached || noop;

--- a/lineal-viz/src/components/lineal/arc/index.ts
+++ b/lineal-viz/src/components/lineal/arc/index.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { cached } from '@glimmer/tracking';
+import { cached } from '../../../cached';
 import { arc } from 'd3-shape';
 import parseAngle from '../../../utils/parse-angle';
 

--- a/lineal-viz/src/components/lineal/arcs/index.ts
+++ b/lineal-viz/src/components/lineal/arcs/index.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { cached } from '@glimmer/tracking';
+import { cached } from '../../../cached';
 import { pie } from 'd3-shape';
 import { Scale, ScaleOrdinal } from '../../../scale';
 import { Accessor, Encoding } from '../../../encoding';

--- a/lineal-viz/src/components/lineal/area/index.ts
+++ b/lineal-viz/src/components/lineal/area/index.ts
@@ -1,6 +1,7 @@
 import { scheduleOnce } from '@ember/runloop';
 import Component from '@glimmer/component';
-import { tracked, cached } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '../../../cached';
 import { area, CurveFactory } from 'd3-shape';
 import { extent } from 'd3-array';
 import { Scale, ScaleLinear } from '../../../scale';

--- a/lineal-viz/src/components/lineal/axis/index.ts
+++ b/lineal-viz/src/components/lineal/axis/index.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
-import { tracked, cached } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '../../../cached';
 import { Scale } from '../../../scale';
 
 enum Orientation {

--- a/lineal-viz/src/components/lineal/gridlines/index.ts
+++ b/lineal-viz/src/components/lineal/gridlines/index.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
-import { tracked, cached } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '../../../cached';
 import { Scale } from '../../../scale';
 
 enum Direction {

--- a/lineal-viz/src/components/lineal/line/index.ts
+++ b/lineal-viz/src/components/lineal/line/index.ts
@@ -1,6 +1,7 @@
 import { scheduleOnce } from '@ember/runloop';
 import Component from '@glimmer/component';
-import { tracked, cached } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '../../../cached';
 import { line } from 'd3-shape';
 import { extent } from 'd3-array';
 import { Scale, ScaleLinear } from '../../../scale';

--- a/lineal-viz/src/scale.ts
+++ b/lineal-viz/src/scale.ts
@@ -1,5 +1,6 @@
 import 'ember-cached-decorator-polyfill';
-import { tracked, cached } from '@glimmer/tracking';
+import { tracked } from '@glimmer/tracking';
+import { cached } from './cached';
 import * as scales from 'd3-scale';
 import Bounds from './bounds';
 import CSSRange from './css-range';


### PR DESCRIPTION
See https://github.com/ef4/ember-auto-import/issues/536

On some versions of Ember (definitely 3.28) when not using Embroider to build an app, importing `cached` from `@glimmer/tracking` results in undefined.

This is a stopgap that at least makes Lineal work with older versions of Ember, even if they don't get the benefits of using `@cached` (the fallback is a no-op).

Hopefully this is indeed recognized as a bug with Ember's build tools and this shim gets to be removed in a future version 🙏 