### PR TITLE
New scale-fn-compute helper for calling compute on scales in templates

### DIFF
--- a/.changeset/fast-bobcats-destroy.md
+++ b/.changeset/fast-bobcats-destroy.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': minor
+---
+
+Introduces scale-fn-compute helper for scale.compute helper compatibility

--- a/lineal-viz/package.json
+++ b/lineal-viz/package.json
@@ -82,6 +82,7 @@
       "./helpers/scale-diverging-sqrt.js": "./dist/_app_/helpers/scale-diverging-sqrt.js",
       "./helpers/scale-diverging-symlog.js": "./dist/_app_/helpers/scale-diverging-symlog.js",
       "./helpers/scale-diverging.js": "./dist/_app_/helpers/scale-diverging.js",
+      "./helpers/scale-fn-compute.js": "./dist/_app_/helpers/scale-fn-compute.js",
       "./helpers/scale-linear.js": "./dist/_app_/helpers/scale-linear.js",
       "./helpers/scale-log.js": "./dist/_app_/helpers/scale-log.js",
       "./helpers/scale-ordinal.js": "./dist/_app_/helpers/scale-ordinal.js",

--- a/lineal-viz/src/helpers/scale-fn-compute.ts
+++ b/lineal-viz/src/helpers/scale-fn-compute.ts
@@ -1,0 +1,4 @@
+import { helper } from '@ember/component/helper';
+import { Scale } from '../scale';
+
+export default helper(([scale, value]: [Scale, any]) => scale.compute(value));

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -22,7 +22,7 @@
 <svg width='800' height='6'>
   {{#let (scale-linear range='15..785' domain='0..10') as |scale|}}
     {{#each (array 0 1 2 3 4 5 6 7 8 9 10) as |v|}}
-      <circle cx={{scale.compute v}} cy='3' r='3'></circle>
+      <circle cx={{scale-fn-compute scale v}} cy='3' r='3'></circle>
     {{/each}}
   {{/let}}
 </svg>


### PR DESCRIPTION
In newer versions of ember, plain function can be used as helpers, like `{{scale.compute 5}}`. Since calling compute on scales in templates is so common, this helper gives the same benefit to users of older versions of Ember: `{{scale-fn-compute scale 5}}`.