### PR TITLE
Pie slice ordering

### DIFF
--- a/.changeset/rotten-trees-battle.md
+++ b/.changeset/rotten-trees-battle.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Bugfix: Do not sort pie slices.

--- a/docs/docs/dev-logs/dev-log-one.md
+++ b/docs/docs/dev-logs/dev-log-one.md
@@ -153,8 +153,8 @@ Donut charts can have rings if you're careful with your radii.
       @cornerRadius={{5}}
       @innerRadius={{102}}
       @outerRadius={{120}}
-      @startAngle='240d'
-      @endAngle='335d'
+      @startAngle='265d'
+      @endAngle='360d'
     />
   </g>
 </svg>

--- a/lineal-viz/src/components/lineal/arcs/index.ts
+++ b/lineal-viz/src/components/lineal/arcs/index.ts
@@ -57,7 +57,8 @@ export default class Arcs extends Component<ArcsArgs> {
       .startAngle(this.startAngle)
       .endAngle(this.endAngle)
       .padAngle(this.padAngle)
-      .value(this.theta.accessor);
+      .value(this.theta.accessor)
+      .sortValues(null);
 
     // Initial dataset
     const arcsData = generator(this.args.data);


### PR DESCRIPTION
`d3.pie` was sorting by value by default, rather than sorting by inherit index order. Now no sorting is applied and it is rightfully the responsibility of the consumer.