### PR TITLE
Lineal::Arcs colorScale and color args bug fixes

### DIFF
--- a/.changeset/rotten-readers-argue.md
+++ b/.changeset/rotten-readers-argue.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Bugfix: Correctly look up color by index or use the color accessor

--- a/lineal-viz/src/components/lineal/arcs/index.ts
+++ b/lineal-viz/src/components/lineal/arcs/index.ts
@@ -22,7 +22,7 @@ export default class Arcs extends Component<ArcsArgs> {
   }
 
   @cached get color() {
-    return new Encoding(this.args.theta);
+    if (this.args.color) return new Encoding(this.args.color);
   }
 
   @cached get colorScale(): Scale {
@@ -31,7 +31,9 @@ export default class Arcs extends Component<ArcsArgs> {
 
     // Or it can be specified as a string provided to CSSRange
     return new ScaleOrdinal({
-      domain: this.args.data.map((d) => this.color.accessor(d)),
+      domain: Array.from(
+        new Set(this.args.data.map(this.color ? (d) => this.color?.accessor(d) : (_, i) => i))
+      ),
       range: new CSSRange(this.args.colorScale ?? 'lineal-arcs'),
     });
   }
@@ -64,11 +66,12 @@ export default class Arcs extends Component<ArcsArgs> {
     const arcsData = generator(this.args.data);
 
     // Augment with color classes or fills
-    arcsData.forEach((d: any) => {
+    arcsData.forEach((d: any, index: number) => {
+      const colorValue = this.colorScale.compute(this.color ? this.color.accessor(d.data) : index);
       if (this.useCSSClass) {
-        d.cssClass = this.colorScale.compute(d.value);
+        d.cssClass = colorValue;
       } else {
-        d.fill = this.colorScale.compute(d.value);
+        d.fill = colorValue;
       }
     });
 

--- a/test-app/app/styles/app.css
+++ b/test-app/app/styles/app.css
@@ -10,6 +10,9 @@
 .reds-3 {
   fill: #6d360f;
 }
+.reds-4 {
+  fill: #480717;
+}
 
 .axis .domain {
   fill: none;

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -241,10 +241,16 @@
 <svg width='400' height='400'>
   <g transform='translate(200 200)'>
     <Lineal::Arcs
-      @data={{array (hash v=1) (hash v=10) (hash v=4)}}
+      @data={{array
+        (hash v=1 c='red')
+        (hash v=0 c='blue')
+        (hash v=10 c='red')
+        (hash v=4 c='fish')
+      }}
       @theta='v'
       @startAngle='270d'
       @endAngle='450d'
+      @color='c'
       @colorScale='reds'
       as |pie|
     >


### PR DESCRIPTION
Yeesh, this is what happens when you forego tests, eh? 😬 

The two bug fixes are:

1. Respect the `@color` encoding. The thread got lost on this one during implementation, but it's back now. Color is typically a `ScaleOrdinal` and this is no different. Now if `@color` is provided, then the set of unique values for the encoding become the domain of a color scale which by default uses a `CSSRange`.
2. In the absence of a `@color` encoding, look up color by index, not by theta value. This way color is both consistent and also unique per slice.