### PR TITLE
Keyboard controls for interactor-cartesian-horizontal

### DIFF
--- a/.changeset/long-vans-itch.md
+++ b/.changeset/long-vans-itch.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': minor
+---
+
+Keyboard events for interactor-cartesian-horizontal

--- a/lineal-viz/src/modifiers/interactor-cartesian-horizontal.ts
+++ b/lineal-viz/src/modifiers/interactor-cartesian-horizontal.ts
@@ -23,6 +23,18 @@ interface ActiveData {
   data: ActiveDatum[];
 }
 
+enum NavKey {
+  ESC = 'Escape',
+  Enter = 'Enter',
+  Space = ' ',
+  Left = 'ArrowLeft',
+  Right = 'ArrowRight',
+  Up = 'ArrowUp',
+  Down = 'ArrowDown',
+}
+
+const NAV_KEYS = Object.values(NavKey);
+
 export default modifier(
   (
     element: HTMLElement,
@@ -34,7 +46,8 @@ export default modifier(
     const yEncs = accessors.map((y) => new Encoding(y));
     const bis = bisector((d) => xEnc.accessor(d)).left;
 
-    let activeData = null;
+    let activeData: ActiveData | null = null;
+    let dataAtThisX: ActiveData[] = [];
 
     function getDataAtPoint(pt: number): ActiveData | null {
       // Exit early when possible
@@ -105,20 +118,39 @@ export default modifier(
       onSelect?.(null);
     }
 
-    // function keyControls(ev: KeyboardEvent) {
-    //   console.log('key controls', ev);
-    // }
+    function keyControls(ev: KeyboardEvent) {
+      const key: NavKey = ev.key as NavKey;
+
+      if (NAV_KEYS.includes(key)) {
+        ev.preventDefault();
+      }
+
+      if (key === NavKey.Space || key === NavKey.Enter) {
+        onSelect?.(activeData ? activeData.datum : null);
+      } else if (key === NavKey.ESC) {
+        onSeek?.(null);
+        onSelect?.(null);
+      } else if (key === NavKey.Up) {
+        console.log('Enc - 1!');
+      } else if (key === NavKey.Down) {
+        console.log('Enc + 1!');
+      } else if (key === NavKey.Right) {
+        console.log('Index + 1!');
+      } else if (key === NavKey.Left) {
+        console.log('Index - 1!');
+      }
+    }
 
     element.addEventListener('mousemove', seek);
     element.addEventListener('click', select);
     element.addEventListener('mouseleave', clear);
-    // element.addEventListener('keydown', keyControls);
+    element.addEventListener('keydown', keyControls);
 
     return () => {
       element.removeEventListener('mousemove', seek);
       element.removeEventListener('click', select);
       element.removeEventListener('mouseleave', clear);
-      // element.removeEventListener('keydown', keyControls);
+      element.removeEventListener('keydown', keyControls);
     };
   },
   { eager: false }

--- a/test-app/app/styles/app.css
+++ b/test-app/app/styles/app.css
@@ -45,6 +45,15 @@
   overflow: visible;
 }
 
+.interactor:focus {
+  outline: none;
+}
+
+.interactor:focus-visible {
+  stroke: rgba(0, 0, 0, 0.2);
+  stroke-width: 4;
+}
+
 .interaction-overlay {
   pointer-events: none;
 }

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -142,6 +142,7 @@
           height={{height}}
           tabindex='0'
           fill='transparent'
+          class='interactor'
           {{interactor-cartesian-horizontal
             data=this.population
             xScale=xScale


### PR DESCRIPTION
This adds common sense keyboard controls to the horizontal cartesian interactor.

1. `ArrowLeft` and `ArrowRight`: cycles through the dataset index by index, calling `onSeek`
2. `Enter` and `Space`: Calls select with active datum
3. `Esc`: Clears data (`onSeek(null)` and `onSelect(null)`)

There's some awkwardness yet around which datum gets selected when pressing Enter or Space when multiple encodings have values for the same x value, but it turns out this is also the case for mouse events since there is no y-axis distance checking. 

I'm not entirely convinced that this multiple encoding with a single dataset is the best API for this interactor to begin with, so I think it's worth letting it marinate as is and see what happens.