### PR TITLE
Bug fix: Yield the tick value and iteration index

### DIFF
--- a/.changeset/tender-turkeys-drive.md
+++ b/.changeset/tender-turkeys-drive.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Bug fixes: Yield the iteration index and the tick value from Lineal::Axis

--- a/lineal-viz/src/components/lineal/axis/index.hbs
+++ b/lineal-viz/src/components/lineal/axis/index.hbs
@@ -3,10 +3,10 @@
     <path class='domain' stroke='currentColor' d={{this.domainPath}}></path>
   {{/if}}
   {{#if (eq this.direction 'horizontal')}}
-    {{#each this.ticks as |tick|}}
+    {{#each this.ticks as |tick index|}}
       <g transform={{tick.transform}}>
         {{#if (has-block)}}
-          {{yield tick}}
+          {{yield tick index}}
         {{else}}
           <line stroke='currentColor' y2={{tick.size}}></line>
           {{#if tick.label}}
@@ -21,10 +21,10 @@
       </g>
     {{/each}}
   {{else}}
-    {{#each this.ticks as |tick|}}
+    {{#each this.ticks as |tick index|}}
       <g transform={{tick.transform}}>
         {{#if (has-block)}}
-          {{yield tick}}
+          {{yield tick index}}
         {{else}}
           <line stroke='currentColor' x2={{tick.size}}></line>
           {{#if tick.label}}

--- a/lineal-viz/src/components/lineal/axis/index.ts
+++ b/lineal-viz/src/components/lineal/axis/index.ts
@@ -168,6 +168,7 @@ export default class Axis extends Component<AxisArgs> {
       textOffset: TEXT_OFFSET[orientation],
       label: format(v),
       textAnchor: TEXT_ANCHOR[orientation],
+      value: v,
     }));
   }
 }

--- a/test-app/tests/integration/components/lineal/axis-test.ts
+++ b/test-app/tests/integration/components/lineal/axis-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, todo } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll, TestContext, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -301,4 +301,11 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
 
     assert.dom('.domain').doesNotExist();
   });
+
+  todo(
+    'When using the block form, each tick is yielded within a translated g',
+    function () {
+      // Getting this patch out asap, will return
+    }
+  );
 });


### PR DESCRIPTION
These were missing from the `Lineal::Axis` block form.