### PR TITLE
Yield the ResizeObserverEntry instance through Lineal::Fluid

### DIFF
--- a/.changeset/lucky-donkeys-retire.md
+++ b/.changeset/lucky-donkeys-retire.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Pass ResizeOberserverEntry object along through Lineal::Fluid

--- a/lineal-viz/src/components/lineal/fluid/index.hbs
+++ b/lineal-viz/src/components/lineal/fluid/index.hbs
@@ -1,3 +1,3 @@
 <div class='lineal-fluid' ...attributes {{did-resize this.onResize}}>
-  {{yield this.width this.height}}
+  {{yield this.width this.height this.entry}}
 </div>

--- a/lineal-viz/src/components/lineal/fluid/index.ts
+++ b/lineal-viz/src/components/lineal/fluid/index.ts
@@ -5,12 +5,14 @@ import { action } from '@ember/object';
 interface FluidArgs {}
 
 export default class Fluid extends Component<FluidArgs> {
-  @tracked width = 0;
-  @tracked height = 10;
+  @tracked width: number = 0;
+  @tracked height: number = 10;
+  @tracked entry: ResizeObserverEntry | undefined;
 
   @action
   onResize(entry: ResizeObserverEntry) {
     this.width = entry.contentRect.width;
     this.height = entry.contentRect.height;
+    this.entry = entry;
   }
 }

--- a/test-app/tests/integration/components/lineal/fluid-test.ts
+++ b/test-app/tests/integration/components/lineal/fluid-test.ts
@@ -2,22 +2,30 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import * as sinon from 'sinon';
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 module('Integration | Component | Lineal::Fluid', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('When first rendering, width and height are immediately yielded', async function (assert) {
+  test('When first rendering, width, height, and the ResizeObserverEntry are immediately yielded', async function (assert) {
+    const spy = sinon.spy();
+    this.setProperties({ spy });
+
     await render(hbs`
-      <Lineal::Fluid style='border:1px solid black; width: 100px; height: 50px' as |width height|>
+      <Lineal::Fluid style='border:1px solid black; width: 100px; height: 50px' as |width height entry|>
         <span class='output'>{{width}} {{height}}</span>
+        {{this.spy entry}}
       </Lineal::Fluid>
     `);
 
     // TODO: This should be replaced with a more precise wait based on the ResizeObserver
     await wait(100);
+
     assert.dom('.output').hasText('100 50');
+    assert.strictEqual(spy.callCount, 2);
+    assert.ok(spy.getCall(1).args[0] instanceof ResizeObserverEntry);
   });
 
   test('Changing the dimensions of the element triggers a recomputation of the width and height', async function (assert) {


### PR DESCRIPTION
The entry object has all of the extra details that comes with a resize event, including the contentRect which has (x,y) coordinate info.

I still believe passing the width and height separately is a nicer API and represents the common case, but we shouldn't inhibit people who need to customize things (a.k.a., me).