### PR TITLE
Points mark pt2

### DIFF
--- a/.changeset/clever-seals-drop.md
+++ b/.changeset/clever-seals-drop.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': minor
+---
+
+A block form for Lineal::Points

--- a/lineal-viz/src/components/lineal/points/index.hbs
+++ b/lineal-viz/src/components/lineal/points/index.hbs
@@ -1,10 +1,15 @@
-{{#each this.points as |p|}}
-  <circle
-    cx={{p.x}}
-    cy={{p.y}}
-    r={{p.size}}
-    fill={{p.fill}}
-    class={{p.cssClass}}
-    ...attributes
-  ></circle>
-{{/each}}
+{{#if (or @renderCircles (not (has-block)))}}
+  {{#each this.points as |p|}}
+    <circle
+      cx={{p.x}}
+      cy={{p.y}}
+      r={{p.size}}
+      fill={{p.fill}}
+      class={{p.cssClass}}
+      ...attributes
+    ></circle>
+  {{/each}}
+{{/if}}
+{{#if (has-block)}}
+  {{yield this.points}}
+{{/if}}

--- a/lineal-viz/src/components/lineal/points/index.ts
+++ b/lineal-viz/src/components/lineal/points/index.ts
@@ -19,14 +19,14 @@ interface PointsArgs {
   renderCircles?: boolean;
 }
 
-export interface PointDatum {
+export type PointDatum = {
   x: number;
   y: number;
   size: number;
   fill?: string;
   cssClass?: string;
   datum: any;
-}
+};
 
 export default class Points extends Component<PointsArgs> {
   @cached get x() {

--- a/lineal-viz/src/components/lineal/points/index.ts
+++ b/lineal-viz/src/components/lineal/points/index.ts
@@ -16,6 +16,7 @@ interface PointsArgs {
   yScale?: Scale;
   sizeScale?: Scale;
   colorScale?: Scale;
+  renderCircles?: boolean;
 }
 
 export interface PointDatum {
@@ -24,6 +25,7 @@ export interface PointDatum {
   size: number;
   fill?: string;
   cssClass?: string;
+  datum: any;
 }
 
 export default class Points extends Component<PointsArgs> {
@@ -90,6 +92,7 @@ export default class Points extends Component<PointsArgs> {
         x: this.xScale.compute(this.x.accessor(d)),
         y: this.yScale.compute(this.y.accessor(d)),
         size: this.sizeScale.compute(this.size.accessor(d)),
+        datum: d,
       };
 
       if (this.colorScale) {

--- a/test-app/app/helpers/fmt.ts
+++ b/test-app/app/helpers/fmt.ts
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+
+const fmtNumber = Intl.NumberFormat('default', { maximumSignificantDigits: 2 });
+const fmtDate = Intl.DateTimeFormat();
+
+export default helper(([value]: [string | number | Date]): string => {
+  if (typeof value === 'string') return value;
+
+  if (typeof value === 'number') return fmtNumber.format(value);
+  if (value instanceof Date) return fmtDate.format(value);
+
+  throw new Error('Bad input!');
+});

--- a/test-app/app/styles/app.css
+++ b/test-app/app/styles/app.css
@@ -99,6 +99,13 @@
   stroke-width: 1px;
 }
 
+.plot-label {
+  font-family: sans-serif;
+  font-size: 12px;
+  alignment-baseline: middle;
+  text-anchor: middle;
+}
+
 #ember-testing .test-svg {
   overflow: visible;
   position: fixed;

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -351,6 +351,7 @@
     <rect x='0' y='0' width='800' height='300' class='svg-border'></rect>
     <Lineal::Points
       @data={{this.frequencyByDay}}
+      @renderCircles={{true}}
       @x='hour'
       @y='dayN'
       @size='value'
@@ -365,7 +366,17 @@
         range=(css-range 'ordinal')
       }}
       class='svg-border-gray'
-    />
+      as |points|
+    >
+      {{#each points as |p|}}
+        <text
+          class='plot-label'
+          x={{p.x}}
+          y={{p.y}}
+          dy={{if (lt p.size 10) '-15'}}
+        >{{fmt p.datum.value}}</text>
+      {{/each}}
+    </Lineal::Points>
   {{/let}}
 </svg>
 


### PR DESCRIPTION
Like `Lineal::Arcs`, having a block form separates the benefits of data processing from rendering marks. This can also be used in conjunction with the default circle rendering for things like labels.

<img width="883" alt="Screen Shot 2022-12-13 at 6 47 17 PM" src="https://user-images.githubusercontent.com/174740/207493026-fcaeec10-30c0-4231-ba11-20449f6dbae7.png">

<details>
<summary>View code snippet</summary>

```hbs
<svg height='300' width='800' class='no-overflow m-100'>
  {{#let
    (scale-linear domain='0..23' range='0..800')
    (scale-linear range='0..300')
    as |xScale yScale|
  }}
    {{#if (and xScale.isValid yScale.isValid)}}
      <Lineal::Gridlines
        @scale={{yScale}}
        @direction='horizontal'
        @length='800'
      />
      <Lineal::Gridlines
        @scale={{xScale}}
        @direction='vertical'
        @length='300'
      />
    {{/if}}
    <rect x='0' y='0' width='800' height='300' class='svg-border'></rect>
    <Lineal::Points
      @data={{this.frequencyByDay}}
      @renderCircles={{true}}
      @x='hour'
      @y='dayN'
      @size='value'
      @color='day'
      @xScale={{xScale}}
      @yScale={{yScale}}
      @sizeScale={{scale-sqrt domain='1..25' range='5..25'}}
      @colorScale={{scale-ordinal
        domain=(array
          'Monday' 'Tuesday' 'Wednesday' 'Thursday' 'Friday' 'Saturday' 'Sunday'
        )
        range=(css-range 'ordinal')
      }}
      class='svg-border-gray'
      as |points|
    >
      {{#each points as |p|}}
        <text
          class='plot-label'
          x={{p.x}}
          y={{p.y}}
          dy={{if (lt p.size 10) '-15'}}
        >{{fmt p.datum.value}}</text>
      {{/each}}
    </Lineal::Points>
  {{/let}}
</svg>
```

</details>