### PR TITLE
New Mark: Lineal::Bars

### DIFF
--- a/.changeset/purple-papayas-buy.md
+++ b/.changeset/purple-papayas-buy.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': minor
+---
+
+Introduces Lineal::Bars mark

--- a/lineal-viz/package.json
+++ b/lineal-viz/package.json
@@ -74,6 +74,7 @@
       "./components/lineal/arcs/index.js": "./dist/_app_/components/lineal/arcs/index.js",
       "./components/lineal/area/index.js": "./dist/_app_/components/lineal/area/index.js",
       "./components/lineal/axis/index.js": "./dist/_app_/components/lineal/axis/index.js",
+      "./components/lineal/bars/index.js": "./dist/_app_/components/lineal/bars/index.js",
       "./components/lineal/fluid/index.js": "./dist/_app_/components/lineal/fluid/index.js",
       "./components/lineal/gridlines/index.js": "./dist/_app_/components/lineal/gridlines/index.js",
       "./components/lineal/line/index.js": "./dist/_app_/components/lineal/line/index.js",

--- a/lineal-viz/src/components/lineal/bars/index.hbs
+++ b/lineal-viz/src/components/lineal/bars/index.hbs
@@ -1,0 +1,3 @@
+{{#each this.bars as |b|}}
+  <rect x={{b.x}} y={{b.y}} width={{b.width}} height={{b.height}} ...attributes></rect>
+{{/each}}

--- a/lineal-viz/src/components/lineal/bars/index.ts
+++ b/lineal-viz/src/components/lineal/bars/index.ts
@@ -1,0 +1,108 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { cached } from '../../../cached';
+import { Accessor, Encoding } from '../../../encoding';
+import { Scale, ScaleLinear, ScaleOrdinal, ScaleSqrt, ScaleIdentity } from '../../../scale';
+import CSSRange from '../../../css-range';
+import { qualifyScale } from '../../../utils/mark-utils';
+
+interface BarsArgs {
+  data: any[];
+  x: Accessor;
+  y: Accessor;
+  width: Accessor;
+  height: Accessor;
+  xScale?: Scale;
+  yScale?: Scale;
+  widthScale?: Scale;
+  heightScale?: Scale;
+}
+
+interface BarDatum {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  datum: any;
+}
+
+export default class Bars extends Component<BarsArgs> {
+  @cached get x() {
+    return new Encoding(this.args.x);
+  }
+
+  @cached get y() {
+    return new Encoding(this.args.y);
+  }
+
+  @cached get width() {
+    return new Encoding(this.args.width);
+  }
+
+  @cached get height() {
+    return new Encoding(this.args.height);
+  }
+
+  @cached get xScale() {
+    if (typeof this.args.x === 'number' && this.args.xScale == null) {
+      return new ScaleIdentity({ range: this.args.x });
+    }
+
+    const scale = this.args.xScale || new ScaleLinear();
+    qualifyScale(this, scale, this.x, 'x');
+    return scale;
+  }
+
+  @cached get yScale() {
+    if (typeof this.args.y === 'number' && this.args.yScale == null) {
+      return new ScaleIdentity({ range: this.args.y });
+    }
+
+    const scale = this.args.yScale || new ScaleLinear();
+    qualifyScale(this, scale, this.y, 'y');
+    return scale;
+  }
+
+  @cached get widthScale() {
+    if (typeof this.args.width === 'number' && this.args.widthScale == null) {
+      return new ScaleIdentity({ range: this.args.width });
+    }
+
+    const scale = this.args.widthScale || new ScaleLinear();
+    qualifyScale(this, scale, this.width, 'width');
+    return scale;
+  }
+
+  @cached get heightScale() {
+    if (typeof this.args.height === 'number' && this.args.heightScale == null) {
+      return new ScaleIdentity({ range: this.args.height });
+    }
+
+    const scale = this.args.heightScale || new ScaleLinear();
+    qualifyScale(this, scale, this.height, 'height');
+    return scale;
+  }
+
+  @cached get bars(): BarDatum[] {
+    if (
+      !this.xScale.isValid ||
+      !this.yScale.isValid ||
+      !this.widthScale.isValid ||
+      !this.heightScale.isValid
+    ) {
+      return [];
+    }
+
+    return this.args.data.map((d: any) => {
+      const bar: BarDatum = {
+        x: this.xScale.compute(this.x.accessor(d)),
+        y: this.yScale.compute(this.y.accessor(d)),
+        width: this.widthScale.compute(this.width.accessor(d)),
+        height: this.heightScale.compute(this.height.accessor(d)),
+        datum: d,
+      };
+
+      return bar;
+    });
+  }
+}

--- a/test-app/app/controllers/application.ts
+++ b/test-app/app/controllers/application.ts
@@ -1,6 +1,8 @@
 import Controller from '@ember/controller';
 import { tracked, cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { ScaleLinear } from '@lineal-viz/lineal/scale';
+import Bounds from '@lineal-viz/lineal/bounds';
 
 const rand = (min: number, max: number): number =>
   Math.random() * (max - min) + min;
@@ -11,6 +13,8 @@ export default class ApplicationController extends Controller {
   daysOfWeek = 'Monday Tuesday Wednesday Thursday Friday Saturday Sunday'.split(
     ' '
   );
+
+  categories = '0-18 18-25 25-35 35-50 50-70 70+'.split(' ');
 
   get population() {
     const data = this.model as any[];
@@ -75,6 +79,17 @@ export default class ApplicationController extends Controller {
       { day: 'Sunday', hour: 2, value: rand(1, 20) },
       { day: 'Sunday', hour: 3, value: rand(1, 20) },
       { day: 'Sunday', hour: 4, value: rand(1, 20) },
+    ];
+  }
+
+  get ageDemo() {
+    return [
+      { bracket: '0-18', value: 10 },
+      { bracket: '18-25', value: 25 },
+      { bracket: '25-35', value: 100 },
+      { bracket: '35-50', value: 30 },
+      { bracket: '50-70', value: 150 },
+      { bracket: '70+', value: 40 },
     ];
   }
 

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -378,4 +378,43 @@
   {{/let}}
 </svg>
 
+<p>Bars</p>
+<svg height='300' width='800' class='no-overflow m-100'>
+  {{#let
+    (scale-band domain=this.categories range='0..800' padding=0.1)
+    (scale-linear range='0..300' domain='0..')
+    (scale-linear range='300..0' domain='0..')
+    as |xScale hScale yScale|
+  }}
+    {{#if (and xScale.isValid yScale.isValid)}}
+      <Lineal::Axis
+        @scale={{yScale}}
+        @orientation='left'
+        @includeDomain={{false}}
+      />
+      <Lineal::Axis
+        @scale={{xScale}}
+        @orientation='bottom'
+        transform='translate(0,{{hScale.range.max}})'
+      />
+      <Lineal::Gridlines
+        @scale={{yScale}}
+        @direction='horizontal'
+        @length='800'
+        stroke-dasharray='5 5'
+      />
+    {{/if}}
+    <Lineal::Bars
+      @data={{this.ageDemo}}
+      @x='bracket'
+      @y='value'
+      @height='value'
+      @width={{xScale.bandwidth}}
+      @xScale={{xScale}}
+      @yScale={{yScale}}
+      @heightScale={{hScale}}
+    />
+  {{/let}}
+</svg>
+
 {{outlet}}

--- a/test-app/tests/integration/components/lineal/bars-test.ts
+++ b/test-app/tests/integration/components/lineal/bars-test.ts
@@ -1,0 +1,90 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, findAll } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { ScaleLinear, ScaleBand } from '@lineal-viz/lineal/scale';
+import Bounds from '@lineal-viz/lineal/bounds';
+
+const getAttrs = (el: Element, ...attrs: string[]) =>
+  attrs.map((attr) => el.getAttribute(attr));
+
+const data = [
+  { cat: 'A', value: 10 },
+  { cat: 'B', value: 20 },
+  { cat: 'C', value: 50 },
+  { cat: 'D', value: 15 },
+];
+
+module('Integration | Component | Lineal::Bars', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Given a dataset and x, y, height, and width accessors and scales, renders bars', async function (assert) {
+    const xScale = new ScaleBand({
+      domain: ['A', 'B', 'C', 'D'],
+      range: '0..100',
+      padding: 0.1,
+    });
+    const yScale = new ScaleLinear({ domain: '0..', range: '100..0' });
+    const heightScale = new ScaleLinear({ domain: '0..', range: '0..100' });
+
+    this.setProperties({ data, xScale, yScale, heightScale });
+
+    await render(hbs`
+      <svg class="test-svg">
+        <Lineal::Bars
+          @data={{this.data}}
+          @x="cat"
+          @y="value"
+          @height="value"
+          @width={{this.xScale.bandwidth}}
+          @xScale={{this.xScale}}
+          @yScale={{this.yScale}}
+          @heightScale={{this.heightScale}}
+        />
+      </svg>
+    `);
+
+    assert.strictEqual(findAll('rect').length, data.length);
+    assert.deepEqual(
+      findAll('rect').map((el: Element) =>
+        getAttrs(el, 'x', 'y', 'width', 'height')
+      ),
+      data.map((d) => [
+        '' + xScale.compute(d.cat),
+        '' + yScale.compute(d.value),
+        '' + xScale.bandwidth,
+        '' + heightScale.compute(d.value),
+      ])
+    );
+  });
+
+  test('When the domain provided on a scale is unqualified, Bars qualifies it using the provided dataset and encoding', async function (assert) {
+    const xScale = new ScaleBand({
+      domain: ['A', 'B', 'C', 'D'],
+      range: '0..100',
+      padding: 0.1,
+    });
+    const yScale = new ScaleLinear({ domain: '0..', range: '100..0' });
+    const heightScale = new ScaleLinear({ domain: '0..', range: '0..100' });
+
+    this.setProperties({ data, xScale, yScale, heightScale });
+
+    await render(hbs`
+      <svg class="test-svg">
+        <Lineal::Bars
+          @data={{this.data}}
+          @x="cat"
+          @y="value"
+          @height="value"
+          @width={{this.xScale.bandwidth}}
+          @xScale={{this.xScale}}
+          @yScale={{this.yScale}}
+          @heightScale={{this.heightScale}}
+        />
+      </svg>
+    `);
+
+    assert.deepEqual((yScale.domain as Bounds<number>).bounds, [0, 50]);
+    assert.deepEqual((heightScale.domain as Bounds<number>).bounds, [0, 50]);
+  });
+});

--- a/test-app/tests/integration/components/lineal/points-test.ts
+++ b/test-app/tests/integration/components/lineal/points-test.ts
@@ -89,7 +89,7 @@ module('Integration | Component | Lineal::Points', function (hooks) {
     );
   });
 
-  test('When the domain provided on a scale is unqualified, Line qualifies it using the provided dataset and encoding', async function (assert) {
+  test('When the domain provided on a scale is unqualified, Points qualifies it using the provided dataset and encoding', async function (assert) {
     const xScale = new ScaleLinear({ domain: '..', range: '0..100' });
     const yScale = new ScaleLinear({ domain: '-10..', range: '0..50' });
 


### PR DESCRIPTION
Bars are `rect` elements with the following encodings:

- `@x`
- `@y`
- `@width`
- `@height`

In the future Bars will also support a color encoding that will implicitly stack bars when two data points have the same `@x` value but different `@color` values.

It looks like this when used with `Lineal::Axis` and `Lineal::Gridlines`

<img width="921" alt="image" src="https://user-images.githubusercontent.com/174740/209403340-ecd0f0de-1f80-4725-b891-e7c3c2ee132b.png">
