### PR TITLE
Bounds.parse converts numeric arrays into Bounds instances

### DIFF
--- a/.changeset/twelve-shirts-protect.md
+++ b/.changeset/twelve-shirts-protect.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Bounds.parse converts two value arrays into Bounds instances

--- a/lineal-viz/src/bounds.ts
+++ b/lineal-viz/src/bounds.ts
@@ -11,7 +11,11 @@ export default class Bounds<T> {
   @tracked max: T | undefined;
 
   static parse(input: string | number[]): Bounds<number> | number[] {
-    if (input instanceof Array) return input;
+    if (input instanceof Array) {
+      if (input.length === 2) return new Bounds<number>(...input);
+      return input;
+    }
+
     if (!NUMERIC_RANGE_DSL.test(input)) {
       throw new Error(
         'Invalid string provided as numeric range. Must match the syntax "1..1", where the min and the max are both optional (e.g., "1.." is valid).'

--- a/test-app/tests/unit/bounds-test.ts
+++ b/test-app/tests/unit/bounds-test.ts
@@ -122,7 +122,12 @@ module('Unit | Bounds.parse', function () {
       },
       { name: '"asdf" is bad input and throws', input: 'asdf', output: null },
       {
-        name: 'when provided with an array, the same array is returned',
+        name: 'when provided with a two element array, it is interpreted as [min, max]',
+        input: [5, 15],
+        output: new Bounds(5, 15),
+      },
+      {
+        name: 'when provided with an array with more than two elements, the same array is returned',
         input: [5, 10, 15],
       },
       {


### PR DESCRIPTION
It's an unpleasant experience to sometimes get something like `scale.domain.min` and other times it is undefined.

Since it's such a common pattern to use two numbers to define a scale, and since scales always go through `Bounds.parse`, it makes sense for `Bounds.parse` to treat two element arrays just like range expressions instead of passing the original array through.

**Before**

```js
const bounds = Bounds.parse([5, 10]); // [5, 10]
console.log(bounds.min); // undefined
```

**After**

```js
const Bounds = Bounds parse([5, 10); // instance of Bounds
console.log(bounds.min); // 5
```