### PR TITLE
API docs for foundational classes and interfaces

### DIFF
--- a/lineal-viz/src/bounds.ts
+++ b/lineal-viz/src/bounds.ts
@@ -6,10 +6,42 @@ import { tracked } from '@glimmer/tracking';
 const NUMBER_PATTERN = '[+-]?\\d+.?\\d*';
 const NUMERIC_RANGE_DSL = new RegExp(`^(${NUMBER_PATTERN})?\.\.(${NUMBER_PATTERN})?$`);
 
+/**
+ * A utility class for modeling a min and max value of a type. Bounds can also be constructed
+ * and passed around before they are "qualified" (i.e., a Bounds can have a `min` but no `max`,
+ * a `max` but no `min`, or even neither a `min` or `max`).
+ *
+ * Being able to create tokens that represent future bounds facilitates in the declarative API
+ * used throughout Lineal.
+ *
+ * When a Bounds instance is ready to be used, it can be qualified with a dataset to compute
+ * the `min` and `max` values based on an accessor function, like how the `extent` function
+ * from the d3-array package works.
+ *
+ * @template T - The min/max data type (typically `number`).
+ */
 export default class Bounds<T> {
+  /** The lower bound. When `undefined`, the Bounds instance is invalid. */
   @tracked min: T | undefined;
+  /** The upper bound. When `undefined`, the Bounds instance is invalid. */
   @tracked max: T | undefined;
 
+  /**
+   * Parses a Bounds instance from a Rust-style range expression.
+   *
+   * ```
+   * const bounds = Bounds.parse('0..');
+   * console.log(bounds.min, bounds.max); // 0, undefined
+   *
+   * const complete = Bounds.parse('-100..100');
+   * console.log(complete.min, complete.max); // -100, 100
+   * ```
+   *
+   * @static
+   * @param input - A Rust-style expression as a string or a numeric array for convience.
+   * @throws - When the provided string is malformed.
+   * @returns - Either a Bounds object or a numeric array (the same one passed as input).
+   */
   static parse(input: string | number[]): Bounds<number> | number[] {
     if (input instanceof Array) {
       if (input.length === 2) return new Bounds<number>(...input);
@@ -29,21 +61,58 @@ export default class Bounds<T> {
     return new Bounds<number>(min, max);
   }
 
-  // TODO: Remove this when https://github.com/ef4/ember-auto-import/pull/512 is released.
-  // Right now in the test-app, Lineal is executed twice (once for the app chunk and again
-  // for the test chunk) which means instanceof checks may not work. Using this gnarly
-  // duck-typing approach is a stopgap.
+  /**
+   * TODO: Remove this when https://github.com/ef4/ember-auto-import/pull/512 is released.
+   * Right now in the test-app, Lineal is executed twice (once for the app chunk and again
+   * for the test chunk) which means instanceof checks may not work. Using this gnarly
+   * duck-typing approach is a stopgap.
+   */
   public readonly __temp_duck_type_bounds: boolean = true;
 
+  /**
+   * Given optional min and max values, construct a Bounds of any type.
+   *
+   * @param [min] - the min value of the bounds, or `undefined` when not yet known.
+   * @param [max] - the max value of the bounds, or `undefined` when not yet known.
+   */
   constructor(min?: T, max?: T) {
     this.min = min;
     this.max = max;
   }
 
+  /**
+   * True when the scale is "qualified" (i.e., has a valid `min` and `max` value).
+   */
   get isValid(): boolean {
     return this.min != undefined && this.max != undefined;
   }
 
+  /**
+   * Replaces `undefined` `min` and `max` values with derived bounds from a provided dataset
+   * using the provided accessor field or function.
+   *
+   * ```
+   * const data = [
+   *   { a: 0, b: 3 },
+   *   { a: -2, b: 5 },
+   *   { a: 10, b: 5 },
+   * ];
+   *
+   * const aBounds = Bounds.parse('..'); // No min or max
+   * aBounds.qualify(data, 'a');
+   * console.log(aBounds.min, aBounds.max); // -2, 10
+   *
+   * const bBounds = Bounds.parse('0..'); // Set min, no max
+   * bBounds.qualify(data, 'b');
+   * console.log(bBounds.min, bBounds.max); // 0, 5
+   * ```
+   *
+   * @param data - An array representing a dataset.
+   * @param  accessor - A function that returns a value for a record in the dataset.
+   *                    When the accessor is a `string`, it is interpreted as a field
+   *                    accessor (e.g., `'foo'` becomes `d => d.foo`)
+   * @throws - When a `min` and `max` cannot be computed using the given dataset and accessor.
+   */
   qualify(data: any[], accessor: string | ((datum: any) => T)): Bounds<T> {
     if (this.min != undefined && this.max != undefined) return this;
 
@@ -60,6 +129,12 @@ export default class Bounds<T> {
     return this;
   }
 
+  /**
+   * A convenient getter for returning the `min` and `max` in a common
+   * two element array format.
+   *
+   * @throws - When the Bounds instance is invalid.
+   */
   get bounds(): [T, T] {
     if (!this.isValid) {
       throw new Error(

--- a/lineal-viz/src/css-range.ts
+++ b/lineal-viz/src/css-range.ts
@@ -1,13 +1,40 @@
-// Used with scales that support discrete ranges (quantize, quantile, threshold, ordinal)
-// to dynamically construct ranges that have incrementing strings. These are then used by
-// marks to specify encodings as css classes instead of as inline attribute values.
+/**
+ * Used with scales that support discrete ranges (quantize, quantile, threshold, and ordinal)
+ * to dynamically construct ranges that have incrementing strings. These are then used by marks
+ * to specify encodings as CSS classes instead of as inline attribute values.
+ */
 export default class CSSRange {
   name: string;
 
+  /**
+   * Creates a class name generator using the provided name as a prefix.
+   *
+   * ```
+   * const range = new CSSRange('blues');
+   * const classes = range.spread(3);
+   * console.log(classes);
+   * // [
+   * //   'blues blues-1 blues-3-1',
+   * //   'blues blues-2 blues-3-2',
+   * //   'blues blues-3 blues-3-3'
+   * // ]
+   * ```
+   *
+   * @param name - The prefix for the generated class names.
+   */
   constructor(name: string) {
     this.name = name;
   }
 
+  /**
+   * Generates a collection of 1 indexed class name sets using the CSSRange's name.
+   * The class name set includes the name itself as well as the name with the index as
+   * well as the name with the index and the count. This way color ramps can be defined
+   * in CSS with as many fallback options as possible to prevent repetive class definitions.
+   *
+   * @param count - The number of class name sets to yield.
+   * @returns - An array of class name sets with a length equal to `count`.
+   */
   spread(count: number): string[] {
     const range = [];
     for (let i = 1; i < count + 1; i++) {

--- a/lineal-viz/src/encoding.ts
+++ b/lineal-viz/src/encoding.ts
@@ -1,9 +1,43 @@
 export type Accessor = (d: any) => any;
 
+/**
+ * A utility class that contains an accessor function
+ * and metadata.
+ *
+ * Encodings are used by marks to model what properties of
+ * a mark can be "encoded" (derivded from a scale and a dataset).
+ */
 export class Encoding {
+  /** The name of a the field when the Encoding is using a field accessor;
+   * `undefined` otherwise. */
   field?: string;
+  /** The accessor function that will return the appropriate value from
+   * a dataset for the encoding. */
   accessor: Accessor;
 
+  /**
+   * Creates an Accessor and captures metadata.
+   *
+   * ```
+   * const fieldAccessor = new Accessor('avg');
+   * const customAccessor = new Accessor(d => d.high - d.low);
+   * const staticAccessor = new Accessor(12);
+   *
+   * const datum = {
+   *   avg: 100,
+   *   high: 112,
+   *   low: 78,
+   * };
+   *
+   * console.log(fieldAccessor.accessor(datum)); // 100
+   * console.log(customAccessor.accessor(datum)); // 34
+   * console.log(staticAccessor.accessor(datum)); // 12
+   * ```
+   *
+   * @param accessor - When the accessor is a `function`, the function is the accessor.
+   *                   When the accessor is a `string`, the string is a field accessor.
+   *                   When the accessor is a `number`, the accessor always returns that number.
+   */
   constructor(accessor: string | number | Accessor) {
     if (typeof accessor === 'string') {
       this.field = accessor;

--- a/lineal-viz/src/scale.ts
+++ b/lineal-viz/src/scale.ts
@@ -35,9 +35,14 @@ export type ValueSet = number[] | string;
  * Continuous scales map a continuous domain to a continuous range (e.g., Linear).
  */
 export interface ContinuousScaleConfig {
+  /** The bounds of the scale's data space. */
   domain?: ValueSet;
+  /** The bounds of the scale's visual space. */
   range?: ValueSet;
+  /** When `true`, values outside the domain are clamped to the min and max of the range
+   * instead of extrapolated beyond the domain's bounds. */
   clamp?: boolean;
+  /** When `true`, domain bounds are rounded to nice numbers. */
   nice?: boolean;
 }
 
@@ -46,6 +51,7 @@ export interface ContinuousScaleConfig {
  * of the exponent.
  */
 export interface PowScaleConfig extends ContinuousScaleConfig {
+  /** The exponent of the power scale (e.g., 10 results in 10, 100, 1000 while 2 results in 2, 4, 8, 16). */
   exponent?: number;
 }
 
@@ -54,6 +60,7 @@ export interface PowScaleConfig extends ContinuousScaleConfig {
  * of the log base.
  */
 export interface LogScaleConfig extends ContinuousScaleConfig {
+  /** The base of the log scale (e.g., e results in a natural log while 10 results in the common log). */
   base?: number;
 }
 
@@ -62,9 +69,14 @@ export interface LogScaleConfig extends ContinuousScaleConfig {
  * an array of Dates, since Dates have complexity beyond numbers.
  */
 export interface DateScaleConfig {
+  /** The bounds of the scale's data space. */
   domain?: Date[];
+  /** The bounds of the scale's visual space. */
   range?: ValueSet;
+  /** When `true`, values outside the domain are clamped to the min and max of the range
+   * instead of extrapolated beyond the domain's bounds. */
   clamp?: boolean;
+  /** When `true`, domain bounds are rounded to nice numbers. */
   nice?: boolean;
 }
 
@@ -74,8 +86,13 @@ export interface DateScaleConfig {
  * neutral base value.
  */
 export interface DivergingScaleConfig {
+  /** The bounds of the scale's data space. Diverging scales have a three-number domain
+   * representing [max-a, mid, max-b] */
   domain: [number, number, number];
+  /** An interpolator that maps a value from -1-1 to a value in visual space.. */
   range: (t: number) => any;
+  /** When `true`, values outside the domain are clamped to the min and max of the range
+   * instead of extrapolated beyond the domain's bounds. */
   clamp?: boolean;
 }
 
@@ -83,7 +100,10 @@ export interface DivergingScaleConfig {
  * Quantize scales map a continuous domain to discrete range.
  */
 export interface QuantizeScaleConfig {
+  /** The extent of a dataset from which equal intervals are derived using the length
+   * of the provided range to determine the interval count.  */
   domain?: ValueSet;
+  /** The set of values for the scale's visual space. */
   range: CSSRange | string[];
 }
 
@@ -91,7 +111,11 @@ export interface QuantizeScaleConfig {
  * Quantile scales map a continuous domain to discrete range.
  */
 export interface QuantileScaleConfig {
+  /** The complete set of data form which equal frequency quantiles are derived using the
+   * length of the provided range to dermine the interval count and the data itself to
+   * determine interval size. */
   domain: number[];
+  /** The set of values for the scale's visual space. */
   range: CSSRange | string[];
 }
 
@@ -99,8 +123,11 @@ export interface QuantileScaleConfig {
  * Ordinal scales map a discrete domain to a discrete range.
  */
 export interface OrdinalScaleConfig {
+  /** The discrete set of ordinal (or nominal) input data. */
   domain?: string[];
+  /** The set of values for the scale's visual space. */
   range: CSSRange | string[];
+  /** The value to use when a computed value is not in the domain. */
   unknown?: string;
 }
 
@@ -109,6 +136,7 @@ export interface OrdinalScaleConfig {
  * (i.e., identify function).
  */
 export interface IdentityScaleConfig {
+  /** The set of values for the scale's visual space and also data space. */
   range: number | number[];
 }
 
@@ -118,12 +146,23 @@ export interface IdentityScaleConfig {
  * the visual space a discrete datum occupies in accordance to the padding properties.
  */
 export interface BandScaleConfig {
+  /** The discrete set of ordinal (or nominal) input data. */
   domain?: string[];
+  /** The bounds of the scale's visual space. */
   range?: ValueSet;
+  /** When `true`, ensures that `step` and `bandwidth` are integers. */
   round?: boolean;
+  /** A number between 0 and 1 that specifies how the outer padding in the scale's
+   * range is distributed. 0.5 represents centering bands in their range. */
   align?: number;
+  /** A convenience property for setting `paddingInner` and `paddingOuter` at once. */
   padding?: number;
+  /** A number between 0 and 1 that specifies how much spacing there is between bands
+   * in proportion to band widths (e.g., when `padding` is 0.5, gaps and bands are
+   * equal widths. */
   paddingInner?: number;
+  /** A number between 0 and 1 that specifies how much padding is placed on the outside
+   * of bands (while still subtracting available space from the `range`). */
   paddingOuter?: number;
 }
 
@@ -132,10 +171,17 @@ export interface BandScaleConfig {
  * the derived `bandwidth` is always zero.
  */
 export interface PointScaleConfig {
+  /** The discrete set of ordinal (or nominal) input data. */
   domain?: string[];
+  /** The bounds of the scale's visual space. */
   range?: ValueSet;
+  /** When `true`, ensures that `step` and `bandwidth` are integers. */
   round?: boolean;
+  /** A number between 0 and 1 that specifies how the outer padding in the scale's
+   * range is distributed. 0.5 represents centering bands in their range. */
   align?: number;
+  /** A number between 0 and 1 that specifies how much padding is placed on the outside
+   * of the points (while still subtracting available space from the `range`). */
   padding?: number;
 }
 

--- a/lineal-viz/src/scale.ts
+++ b/lineal-viz/src/scale.ts
@@ -406,14 +406,26 @@ export class ScaleUtc extends AbstractScaleTime {
   }
 }
 
+/**
+ * A scale that maps a domain of two diverging values and a midpoint to a value between -1 and 1
+ * and then passes that number to a range interpolator.
+ */
 export class ScaleDiverging<T> implements Scale {
+  /** The bounds of the scale's data space. Diverging scales have a three-number domain
+   * representing [max-a, mid, max-b] */
   @tracked domain: [number, number, number];
-  @tracked range: (t: number) => T; // Interpolator
+  /** An interpolator that maps a value from -1-1 to a value in visual space.. */
+  @tracked range: (t: number) => T;
+  /** When `true`, values outside the domain are clamped to the min and max of the range
+   * instead of extrapolated beyond the domain's bounds. */
   @tracked clamp: boolean = false;
 
-  // Scale does not support bounds, it's always valid
+  /** Diverging scales do not support `Bounds` and are therefore always valid. */
   isValid = true;
 
+  /**
+   * The underlying d3Scale function before setting parameters.
+   */
   protected scaleFn: (interpolator?: (t: number) => T) => scales.ScaleDiverging<any, any> =
     scales.scaleDiverging;
 
@@ -423,33 +435,58 @@ export class ScaleDiverging<T> implements Scale {
     this.clamp = clamp ?? false;
   }
 
+  /**
+   * The final d3Scale used for computation.
+   */
   @cached get d3Scale() {
     const scale = this.scaleFn(this.range).domain(this.domain);
     if (this.clamp) scale.clamp(true);
     return scale;
   }
 
+  /**
+   * Computes a range value from a domain value.
+   */
   compute = (value: number): T => {
     return this.d3Scale(value);
   };
 }
 
+/**
+ * A scale that maps a domain of two diverging values and a midpoint to a value between -1 and 1
+ * along a logarithmic curve and then passes that number to a range interpolator.
+ */
 export class ScaleDivergingLog<T> extends ScaleDiverging<T> {
   protected scaleFn = scales.scaleDivergingLog;
 }
 
+/**
+ * A scale that maps a domain of two diverging values and a midpoint to a value between -1 and 1
+ * along a power curve and then passes that number to a range interpolator.
+ */
 export class ScaleDivergingPow<T> extends ScaleDiverging<T> {
   protected scaleFn = scales.scaleDivergingPow;
 }
 
+/**
+ * A scale that maps a domain of two diverging values and a midpoint to a value between -1 and 1
+ * along a square root curve and then passes that number to a range interpolator.
+ */
 export class ScaleDivergingSqrt<T> extends ScaleDiverging<T> {
   protected scaleFn = scales.scaleDivergingSqrt;
 }
 
+/**
+ * A scale that maps a domain of two diverging values and a midpoint to a value between -1 and 1
+ * along a symmetric log curve and then passes that number to a range interpolator.
+ */
 export class ScaleDivergingSymlog<T> extends ScaleDiverging<T> {
   protected scaleFn = scales.scaleDivergingSymlog;
 }
 
+/**
+ * A scale that maps a domain of values to a discrete set of range values.
+ */
 export class ScaleQuantize implements Scale {
   @tracked domain: Bounds<number> | number[];
   @tracked range: CSSRange | string[];
@@ -485,7 +522,6 @@ export class ScaleQuantile implements Scale {
   @tracked domain: number[];
   @tracked range: CSSRange | string[];
 
-  // Scale does not support bounds, it's always valid
   isValid = true;
 
   constructor({ domain, range }: QuantileScaleConfig) {
@@ -508,7 +544,6 @@ export class ScaleThreshold implements Scale {
   @tracked domain: number[];
   @tracked range: CSSRange | string[];
 
-  // Scale does not support bounds, it's always valid
   isValid = true;
 
   constructor({ domain, range }: QuantileScaleConfig) {
@@ -532,7 +567,6 @@ export class ScaleOrdinal implements Scale {
   @tracked range: CSSRange | string[];
   @tracked unknown: string | undefined;
 
-  // Scale does not support bounds, it's always valid
   isValid = true;
 
   constructor({ domain, range, unknown }: OrdinalScaleConfig) {
@@ -561,7 +595,6 @@ export class ScaleOrdinal implements Scale {
 export class ScaleIdentity implements Scale {
   @tracked range: number[];
 
-  // Scale does not support bounds, it's always valid
   isValid = true;
 
   constructor({ range }: IdentityScaleConfig) {

--- a/lineal-viz/src/utils/curves.ts
+++ b/lineal-viz/src/utils/curves.ts
@@ -68,5 +68,10 @@ export const curveFor = (
 
   // In the event someone passes in curve args for a curve that takes no args,
   // just return the appropriate scale
+  if (!CURVES[curveArgs.name]) {
+    throw new Error(
+      `No curve factory "${curveArgs.name}". See all curve factories here: https://github.com/d3/d3-shape#curves`
+    );
+  }
   return CURVES[curveArgs.name];
 };

--- a/lineal-viz/src/utils/curves.ts
+++ b/lineal-viz/src/utils/curves.ts
@@ -7,6 +7,11 @@ export type CurveArgs = {
   alpha?: number;
 };
 
+/**
+ * A mapping of `string`s to D3 curve factories.
+ *
+ * This is useful for safely specifying curve functions in templates.
+ */
 export const CURVES: { [key: string]: shape.CurveFactory | shape.CurveBundleFactory } = {
   basis: shape.curveBasis,
   basisClosed: shape.curveBasisClosed,
@@ -30,6 +35,14 @@ export const CURVES: { [key: string]: shape.CurveFactory | shape.CurveBundleFact
   stepBefore: shape.curveStepBefore,
 };
 
+/**
+ * Creates a curve function from a string or argument object.
+ *
+ * @param [curve] - When a string, looks up the corresponding curve factory and returns it.
+ *                  When a `CurveArgs`, looks up the corresponding curve factory based on `curve.name`,
+ *                  applies parameters, and returns the resulting curve function.
+ * @throws {Error} - When there is no curve factory for the specified curve.
+ */
 export const curveFor = (
   curve?: string | CurveArgs
 ): shape.CurveFactory | shape.CurveBundleFactory => {


### PR DESCRIPTION
Now that TypeDoc docs are being published, it's type to level up in-source documentation (which will benefit editor intellisense too 🎉 )

This first push gets the foundational things like Scale, Bounds, CSSRange, and Encoding documented.

The next push will document args for the Ember things (component, helpers, modifiers).

Most things are built on top of these foundational pieces, and since TypeDoc docs link types together, the experience right now of starting with a component and drilling into an Encoding, for instance, isn't the worst.