### PR TITLE
License in packages

### DIFF
--- a/.changeset/rich-turkeys-marry.md
+++ b/.changeset/rich-turkeys-marry.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Update package.json so properly state MPL-2.0 license instead of MIT

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Small description for docs goes here",
   "repository": "",
-  "license": "MIT",
+  "license": "MPL-2.0",
   "author": "",
   "directories": {
     "doc": "doc",

--- a/lineal-viz/package.json
+++ b/lineal-viz/package.json
@@ -6,8 +6,12 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "",
-  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashicorp/lineal",
+    "directory": "lineal-viz"
+  },
+  "license": "MPL-2.0",
   "author": "",
   "files": [
     "addon-main.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "version": "0.0.0",
   "private": true,
-  "repository": "",
-  "license": "MIT",
+  "repository": "https://github.com/hashicorp/lineal",
+  "license": "MPL-2.0",
   "author": "",
   "scripts": {
     "prepare": "yarn workspace @lineal-viz/lineal run prepare",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Small description for test-app goes here",
   "repository": "",
-  "license": "MIT",
+  "license": "MPL-2.0",
   "author": "",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This project has [always been licensed under MPL-2.0](https://github.com/hashicorp/lineal/commit/54e4a9bfbbacde0f6d35c924bd5b57e5d58b9caf), as is required of all HashiCorp open source projects.

This change updates the license metadata in package.json files so the appropriate license is picked up by NPM and other metadata consumers.