### PR TITLE
More docs

### DIFF
--- a/lineal-viz/src/modifiers/interactor-cartesian-horizontal.ts
+++ b/lineal-viz/src/modifiers/interactor-cartesian-horizontal.ts
@@ -8,23 +8,41 @@ import { Scale } from '../scale';
 import { Accessor, Encoding } from '../encoding';
 import { bisector } from 'd3-array';
 
+/**
+ * The available arguments to the `interactor-cartesian-horizontal` modifier.
+ */
 export interface InteractorArgs {
+  /** A dataset of any type of data. */
   data: any[];
+  /** The scale the represents the x-axis of the plot being interacted with. */
   xScale: Scale;
+  /** The accessor for the x encoding of the plot being interacted with. */
   x: Accessor;
+  /** The accessor (or accessors) for looking up data encoded on the y-axis. */
   y: Accessor | Accessor[];
+  /** How sensitive rounding is when determining if near data should be included in
+   * a selection. Measured in pixel space (i.e., after values have been computed by scales). */
   distanceThreshold: number;
+  /** Called when the the modified element receives mouse movement or left/right arrow key input. */
   onSeek?: (data: ActiveData | null) => void;
+  /** Called when the the modified element receives mouse click or space/enter key input. */
   onSelect?: (datum: ActiveDatum | null) => void;
 }
 
 export interface ActiveDatum {
+  /** The encoding that corresponds to the `datum`. Useful for determining which
+   * series the `datum` belongs to. */
   encoding: Encoding;
+  /** An element from the data array provided to the Modifier. */
   datum: any;
 }
 
 export interface ActiveData {
+  /** The element from the data array provided to the Modifier that is
+   * closest to the interaction point. */
   datum: ActiveDatum;
+  /** Surrounding data from the data array provided to the Modifier that is close
+   * to the interaction point (as determined by the `distanceThreshold`). */
   data: ActiveDatum[];
 }
 

--- a/lineal-viz/src/utils/mark-utils.ts
+++ b/lineal-viz/src/utils/mark-utils.ts
@@ -9,10 +9,25 @@ import Bounds from '../bounds';
 import { Scale } from '../scale';
 import { Encoding } from '../encoding';
 
+/**
+ * A valid Mark component must have a `data` arg.
+ */
 export interface MarkArgs {
   data: any[];
 }
 
+/**
+ * This is used internally by Marks to qualify a scale with the data arg
+ * on the next tick of the runloop (to avoid mutating a property twice in
+ * the same render).
+ *
+ * @param context - A Lineal Mark comonent
+ * @param scale - The scale to qualify
+ * @param encoding - The encoding whose accesor to use for data lookups
+ * @param field - The name of the encoded channel (used for formatting error messages)
+ * @throws - When the scale has an invalid range (which is not computed as
+ *           part of scale qualification)
+ */
 export function qualifyScale(
   context: Component<MarkArgs>,
   scale: Scale,

--- a/lineal-viz/src/utils/parse-angle.ts
+++ b/lineal-viz/src/utils/parse-angle.ts
@@ -3,7 +3,21 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-// An angle can be defined as a number or a string ending with 'd'
+/**
+ * Converts a well-formed degrees string into radians or passes through radians
+ * if provided with numberic input.
+ *
+ * ```
+ * console.log(parseAngle('180d'); // 3.141592653589793
+ * console.log(parseAngle(Math.PI); // 3.141592653589793
+ * ```
+ *
+ * @param angle - When a number, the number is assumed to be radians and is returned as is.
+ *                When a string, the number is parsed as degrees and converted to radians
+ *                as long as the string ends in a lower-case 'd'.
+ * @throws - When the string `angle` is malformed.
+ * @returns - The provided angle as radians.
+ */
 export default function parseAngle(angle: number | string): number {
   if (typeof angle === 'number') return angle;
 


### PR DESCRIPTION
For

1. parse-angle
2. mark-utils
3. interactor-cartesian-horizontal

I would like for all the component interfaces be documented eventually too, but for now I think this is a good balance. Between conceptual documentation and clicking through to primitives, I think the components will have pretty good documentation coverage.