### PR TITLE
Scale#derive

### DIFF
--- a/.changeset/three-cheetahs-visit.md
+++ b/.changeset/three-cheetahs-visit.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': minor
+---
+
+New Scale#derive method available on all scales

--- a/lineal-viz/src/css-range.ts
+++ b/lineal-viz/src/css-range.ts
@@ -47,4 +47,8 @@ export default class CSSRange {
     }
     return range;
   }
+
+  copy(): CSSRange {
+    return new CSSRange(this.name);
+  }
 }

--- a/lineal-viz/src/helpers/scale-fn-derive.ts
+++ b/lineal-viz/src/helpers/scale-fn-derive.ts
@@ -1,0 +1,4 @@
+import { helper } from '@ember/component/helper';
+import { Scale } from '../scale';
+
+export default helper(([scale]: [Scale], config: object) => scale.derive(config));

--- a/lineal-viz/src/scale.ts
+++ b/lineal-viz/src/scale.ts
@@ -28,6 +28,9 @@ export interface Scale {
   /** Whether or not calling scale.compute will result in an error.
    * `isValid` is `false` when the scale's domain or range are unqualified. */
   isValid: boolean;
+  /** Creates a new scale of the same type and same properties. The options Config overrides
+   * any set properties (like `Object.assign`). */
+  // derive: (options: any) => Scale;
 }
 
 /**
@@ -202,10 +205,15 @@ abstract class ScaleContinuous implements Scale {
   @tracked nice: boolean | number = false;
 
   constructor({ domain, range, clamp, nice }: ContinuousScaleConfig = {}) {
-    this.domain = domain ? Bounds.parse(domain) : new Bounds();
-    this.range = range ? Bounds.parse(range) : new Bounds();
+    this.domain = this.boundsFromArg(domain);
+    this.range = this.boundsFromArg(range);
     this.clamp = clamp ?? false;
     this.nice = nice ?? false;
+  }
+
+  private boundsFromArg(arg?: ValueSet): Bounds<number> | number[] {
+    if (arg instanceof Bounds) return arg;
+    return arg ? Bounds.parse(arg) : new Bounds();
   }
 
   /**
@@ -222,6 +230,7 @@ abstract class ScaleContinuous implements Scale {
    * The d3Scale instance without generic modifications like clamp and nice applied yet.
    */
   abstract get _d3Scale(): scales.ScaleContinuousNumeric<number, number>;
+  abstract derive(options: ContinuousScaleConfig): ScaleContinuous;
 
   /**
    * The final d3Scale used for computation.
@@ -263,6 +272,20 @@ export class ScaleLinear extends ScaleContinuous {
   get _d3Scale() {
     return scales.scaleLinear(...this.scaleArgs);
   }
+
+  derive = (options: ContinuousScaleConfig): ScaleLinear => {
+    return new ScaleLinear(
+      Object.assign(
+        {
+          domain: this.domain instanceof Bounds ? this.domain.copy() : this.domain.slice(),
+          range: this.range instanceof Bounds ? this.range.copy() : this.range.slice(),
+          clamp: this.clamp,
+          nice: this.nice,
+        },
+        options
+      )
+    );
+  };
 }
 
 /**
@@ -280,6 +303,21 @@ export class ScalePow extends ScaleContinuous {
   get _d3Scale() {
     return scales.scalePow(...this.scaleArgs).exponent(this.exponent);
   }
+
+  derive = (options: ContinuousScaleConfig): ScalePow => {
+    return new ScalePow(
+      Object.assign(
+        {
+          domain: this.domain,
+          range: this.range,
+          clamp: this.clamp,
+          nice: this.nice,
+          exponent: this.exponent,
+        },
+        options
+      )
+    );
+  };
 }
 
 /**
@@ -297,6 +335,21 @@ export class ScaleLog extends ScaleContinuous {
   get _d3Scale() {
     return scales.scaleLog(...this.scaleArgs).base(this.base);
   }
+
+  derive = (options: ContinuousScaleConfig): ScaleLog => {
+    return new ScaleLog(
+      Object.assign(
+        {
+          domain: this.domain,
+          range: this.range,
+          clamp: this.clamp,
+          nice: this.nice,
+          base: this.base,
+        },
+        options
+      )
+    );
+  };
 }
 
 /**
@@ -306,6 +359,20 @@ export class ScaleSqrt extends ScaleContinuous {
   get _d3Scale() {
     return scales.scaleSqrt(...this.scaleArgs);
   }
+
+  derive = (options: ContinuousScaleConfig): ScaleSqrt => {
+    return new ScaleSqrt(
+      Object.assign(
+        {
+          domain: this.domain,
+          range: this.range,
+          clamp: this.clamp,
+          nice: this.nice,
+        },
+        options
+      )
+    );
+  };
 }
 
 /**
@@ -315,6 +382,20 @@ export class ScaleSymlog extends ScaleContinuous {
   get _d3Scale() {
     return scales.scaleSymlog(...this.scaleArgs);
   }
+
+  derive = (options: ContinuousScaleConfig): ScaleSymlog => {
+    return new ScaleSymlog(
+      Object.assign(
+        {
+          domain: this.domain,
+          range: this.range,
+          clamp: this.clamp,
+          nice: this.nice,
+        },
+        options
+      )
+    );
+  };
 }
 
 /**
@@ -325,6 +406,20 @@ export class ScaleRadial extends ScaleContinuous {
   get _d3Scale() {
     return scales.scaleRadial(...this.scaleArgs);
   }
+
+  derive = (options: ContinuousScaleConfig): ScaleRadial => {
+    return new ScaleRadial(
+      Object.assign(
+        {
+          domain: this.domain,
+          range: this.range,
+          clamp: this.clamp,
+          nice: this.nice,
+        },
+        options
+      )
+    );
+  };
 }
 
 abstract class AbstractScaleTime implements Scale {

--- a/test-app/tests/unit/bounds-test.ts
+++ b/test-app/tests/unit/bounds-test.ts
@@ -105,6 +105,17 @@ module('Unit | Bounds', function () {
       scale.bounds;
     }, /not been qualified/);
   });
+
+  test('copy returns a new Bounds instance with identical properties', function (assert) {
+    const bounds = new Bounds(0, 100);
+    const unqualifiedBounds = Bounds.parse('10..');
+    const piecewiseBounds = new Bounds<number>([0, 20, 80, 1000]);
+
+    assert.deepEqual(bounds.bounds, bounds.copy().bounds);
+    assert.deepEqual(unqualifiedBounds.min, unqualifiedBounds.copy().min);
+    assert.deepEqual(unqualifiedBounds.max, unqualifiedBounds.copy().max);
+    assert.deepEqual(piecewiseBounds.bounds, piecewiseBounds.copy().bounds);
+  });
 });
 
 module('Unit | Bounds.parse', function () {
@@ -132,8 +143,19 @@ module('Unit | Bounds.parse', function () {
         output: new Bounds(5, 15),
       },
       {
-        name: 'when provided with an array with more than two elements, the same array is returned',
+        name: 'when provided with an array with more than two elements, a piecewise Bounds is returned',
         input: [5, 10, 15],
+        output: new Bounds<number>([5, 10, 15]),
+      },
+      {
+        name: 'when provided with an array with one element, a bounds with equal min and max is returend',
+        input: [5],
+        output: new Bounds(5, 5),
+      },
+      {
+        name: 'when provided with an array with zero elements, a bounds with undefiend min and max is returend',
+        input: [],
+        output: new Bounds(),
       },
       {
         name: '"0.5..10.2" respects decimals and has 0.5 as min and 10.2 as max',
@@ -162,14 +184,12 @@ module('Unit | Bounds.parse', function () {
         assert.throws(() => {
           Bounds.parse(t.input);
         });
-      } else if (t.output instanceof Bounds) {
+      } else if (t.output) {
         const { min, max } = Bounds.parse(t.input) as Bounds<number>;
         assert.deepEqual(
           { min, max },
           { min: t.output.min, max: t.output.max }
         );
-      } else {
-        assert.strictEqual(Bounds.parse(t.input), t.input as number[]);
       }
     }
   );

--- a/test-app/tests/unit/css-range-test.ts
+++ b/test-app/tests/unit/css-range-test.ts
@@ -25,4 +25,11 @@ module('Unit | CSSRange', function () {
       'foo foo-3 foo-3-3',
     ]);
   });
+
+  test('The copy method returns a new CSSRange instance with the same name', function (assert) {
+    const range = new CSSRange('clone');
+    const copy = range.copy();
+    assert.strictEqual(range.name, copy.name);
+    assert.notStrictEqual(range, copy);
+  });
 });

--- a/test-app/tests/unit/scale-test.ts
+++ b/test-app/tests/unit/scale-test.ts
@@ -83,6 +83,17 @@ module('Unit | ScaleLinear', function () {
     assert.ok(scale.d3Scale.clamp());
     assert.strictEqual(scale.compute(11), 100);
   });
+
+  test('derive creates a copy of the original scale, overriding properties set in the provided config', function (assert) {
+    const scale = new ScaleLinear({ range: '10..100', domain: '1..10' });
+    const newScale = scale.derive({ clamp: true, range: '0..200' });
+
+    assert.notStrictEqual(scale, newScale);
+    assert.deepEqual((newScale.range as Bounds<number>).bounds, [0, 200]);
+    assert.ok(newScale.clamp);
+    assert.notOk(scale.clamp);
+    assert.notStrictEqual(scale.domain, newScale.domain);
+  });
 });
 
 module('Unit | ScaleUtc', function () {


### PR DESCRIPTION
Ever want to take a scale but tweak it but like in a declarative way? Now you can!

You have always been able to do something like this thanks to the magic of tracked properties:

```ts
// Make a scale
const scale = new ScalePow({ ... props });

// And tweak it
scale.clamp = true;
```

But this isn't very helpful when you're making components and accepting scales as args


```hbs
{{! call site }}
<ChartComponent @data={{this.data}} @scale={{scale-linear props}} />
```

```hbs
{{! chart-component/index.hbs }}
<LinealFluid as |width|>
  {{! but wait, I want to set the range on the scale to use `width` here}}
  <Points @data={{@data}} @xScale={{@scale}} />
</LinealFluid>
```

Now this is simple to do with just handlebars

```hbs
{{! chart-component/index.hbs }}
<LinealFluid as |width|>
  {{!-- 
    this preserves the properties of the scale provided to the component
    while overriding the range.
  --}}
  {{#let (@scale.derive range=(array 0 width)) as |scale|}}
    <Points @data={{@data}} @xScale={{scale}} />
  {{/let}}
</LinealFluid>
```

------------

So doing this forced a Bounds refactor. Now Bounds knows what to do with piecewise ranges. This greatly simplified types in Scales and made implementing derive much less encumbered with type checking and casting.