### PR TITLE
Scale ticks

### DIFF
--- a/.changeset/chatty-eggs-scream.md
+++ b/.changeset/chatty-eggs-scream.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': minor
+---
+
+New scale.ticks getter for scales that support ticks

--- a/lineal-viz/package.json
+++ b/lineal-viz/package.json
@@ -93,6 +93,7 @@
       "./helpers/scale-diverging-symlog.js": "./dist/_app_/helpers/scale-diverging-symlog.js",
       "./helpers/scale-diverging.js": "./dist/_app_/helpers/scale-diverging.js",
       "./helpers/scale-fn-compute.js": "./dist/_app_/helpers/scale-fn-compute.js",
+      "./helpers/scale-fn-derive.js": "./dist/_app_/helpers/scale-fn-derive.js",
       "./helpers/scale-identity.js": "./dist/_app_/helpers/scale-identity.js",
       "./helpers/scale-linear.js": "./dist/_app_/helpers/scale-linear.js",
       "./helpers/scale-log.js": "./dist/_app_/helpers/scale-log.js",

--- a/lineal-viz/src/scale.ts
+++ b/lineal-viz/src/scale.ts
@@ -272,6 +272,13 @@ abstract class ScaleContinuous implements Scale {
   get isValid(): boolean {
     return this.domain.isValid && this.range.isValid;
   }
+
+  /**
+   * The default tick values for the scale. These are domain values, not range values.
+   */
+  get ticks() {
+    return this.d3Scale.ticks();
+  }
 }
 
 /**
@@ -470,6 +477,13 @@ abstract class AbstractScaleTime implements Scale {
    */
   get isValid(): boolean {
     return this.domain.isValid && this.range.isValid;
+  }
+
+  /**
+   * The default tick values for the scale. These are domain values, not range values.
+   */
+  get ticks() {
+    return this.d3Scale.ticks();
   }
 }
 
@@ -697,6 +711,13 @@ export class ScaleQuantize implements Scale {
   get isValid(): boolean {
     return this.domain.isValid;
   }
+
+  /**
+   * The default tick values for the scale. These are domain values, not range values.
+   */
+  get ticks() {
+    return this.d3Scale.ticks();
+  }
 }
 
 /**
@@ -911,6 +932,13 @@ export class ScaleIdentity implements Scale {
       )
     );
   };
+
+  /**
+   * The default tick values for the scale. These are domain values, not range values.
+   */
+  get ticks() {
+    return this.d3Scale.ticks();
+  }
 }
 
 /**

--- a/test-app/tests/unit/scale-test.ts
+++ b/test-app/tests/unit/scale-test.ts
@@ -94,6 +94,12 @@ module('Unit | ScaleLinear', function () {
     assert.notOk(scale.clamp);
     assert.notStrictEqual(scale.domain, newScale.domain);
   });
+
+  test('the ticks getter returns the d3Scale ticks with default args', function (assert) {
+    const scale = new ScaleLinear({ range: '10..100', domain: '1..10' });
+
+    assert.deepEqual(scale.ticks, scale.d3Scale.ticks());
+  });
 });
 
 module('Unit | ScaleUtc', function () {


### PR DESCRIPTION
Exposing scale ticks through a getter allows for things like this:


```hbs
{{#let (scale-linear domain="0..10" range="0..100") as |scale|}}
  {{! bespoke axis-like visual elements }}
  {{#each scale.ticks as |tick|}}
    {{scale.compute tick}}
  {{/each}}
{{/let}}
```