### PR TITLE
Concept Docs Scaffolding + Scales Docs

### DIFF
--- a/docs/.docfy-config.js
+++ b/docs/.docfy-config.js
@@ -23,5 +23,6 @@ module.exports = {
   ],
   labels: {
     'dev-logs': 'Dev Logs',
+    concepts: 'Concepts',
   },
 };

--- a/docs/app/components/diverging-scale-demo/index.hbs
+++ b/docs/app/components/diverging-scale-demo/index.hbs
@@ -1,0 +1,8 @@
+<div class='flex-grid'>
+  {{#each @data as |d|}}
+    <div class='diverging-scale-datum'>
+      {{d.x}}
+      <div {{style background-color=(@scale.compute d.x)}}></div>
+    </div>
+  {{/each}}
+</div>

--- a/docs/app/components/partitioning-scale-demo/index.hbs
+++ b/docs/app/components/partitioning-scale-demo/index.hbs
@@ -1,0 +1,7 @@
+{{#if this.scale.isValid}}
+  <div class='waffle-chart'>
+    {{#each @data as |d|}}
+      <div class={{this.scale.compute d.y}}><span>{{fmt d.y}}</span></div>
+    {{/each}}
+  </div>
+{{/if}}

--- a/docs/app/components/partitioning-scale-demo/index.js
+++ b/docs/app/components/partitioning-scale-demo/index.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { scheduleOnce } from '@ember/runloop';
+import Bounds from '@lineal-viz/lineal/bounds';
+
+export default class PartitioningScaleDemo extends Component {
+  @cached get scale() {
+    const scale = this.args.scale;
+
+    if (scale.domain instanceof Bounds && !scale.domain.isValid) {
+      scheduleOnce('afterRender', this, () => {
+        scale.domain.qualify(this.args.data, 'y');
+      });
+    }
+
+    return scale;
+  }
+}

--- a/docs/app/components/scale-demo/index.hbs
+++ b/docs/app/components/scale-demo/index.hbs
@@ -1,0 +1,27 @@
+<div class='demo-chart-with-axes'>
+  <Lineal::Fluid as |width height|>
+    {{#let (@scale.derive range=(array 0 width)) as |scale|}}
+      <svg width='100%' height='20px' style='overflow:visible'>
+        {{#if scale.isValid}}
+          <Lineal::Gridlines
+            @direction='vertical'
+            @scale={{scale}}
+            @length={{20}}
+          />
+          <Lineal::Axis
+            @orientation='bottom'
+            @scale={{scale}}
+            transform='translate(0,20)'
+          />
+        {{/if}}
+        <Lineal::Points
+          @data={{@data}}
+          @x='x'
+          @xScale={{scale}}
+          @y={{10}}
+          @size={{3}}
+        />
+      </svg>
+    {{/let}}
+  </Lineal::Fluid>
+</div>

--- a/docs/app/helpers/color-interpolator.js
+++ b/docs/app/helpers/color-interpolator.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+import * as d3 from 'd3-scale-chromatic';
+
+export default helper(([name]) => {
+  // Pretty unsafe thing to do!
+  return (t) => d3[name](1 - t);
+});

--- a/docs/app/helpers/date.js
+++ b/docs/app/helpers/date.js
@@ -1,0 +1,3 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(([value]) => new Date(value));

--- a/docs/app/helpers/generate-linear-dates.js
+++ b/docs/app/helpers/generate-linear-dates.js
@@ -1,0 +1,19 @@
+import { helper } from '@ember/component/helper';
+
+function* linearDates(length, options) {
+  const { start, step } = Object.assign(
+    { start: new Date(), step: 7 },
+    options
+  );
+
+  let x = start instanceof Date ? start : new Date(start);
+  for (let i = 0; i < length; i++) {
+    yield { x, y: x };
+    x = new Date(+x + step * 24 * 60 * 60 * 1000);
+  }
+}
+
+export default helper(([length], options) => {
+  const gen = linearDates(length, options);
+  return Array.from(gen);
+});

--- a/docs/app/helpers/generate-linear.js
+++ b/docs/app/helpers/generate-linear.js
@@ -1,0 +1,16 @@
+import { helper } from '@ember/component/helper';
+
+function* linear(length, options) {
+  const { start, step } = Object.assign({ start: 0, step: 10 }, options);
+
+  let x = start;
+  for (let i = 0; i < length; i++) {
+    yield { x, y: x };
+    x += step;
+  }
+}
+
+export default helper(([length], options) => {
+  const gen = linear(length, options);
+  return Array.from(gen);
+});

--- a/docs/app/helpers/generate-normal.js
+++ b/docs/app/helpers/generate-normal.js
@@ -1,0 +1,19 @@
+function* normal(length, options) {
+  const { mean, stddev } = Object.assign({ mean: 0, stddev: 1 }, options);
+
+  for (let x = 0; x < length; x++) {
+    const u = Math.random();
+    const v = Math.random();
+    const norm = Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+    const y = norm * stddev - -mean;
+    yield { x, y };
+  }
+}
+
+import { helper } from '@ember/component/helper';
+
+export default helper(([length], options) => {
+  const gen = normal(length, options);
+  const data = Array.from(gen);
+  return options.sort ? data.sort((a, b) => a.y - b.y) : data;
+});

--- a/docs/app/styles/app.css
+++ b/docs/app/styles/app.css
@@ -495,9 +495,11 @@ dl {
   }
 
   .axis line,
-  .axis path {
+  .axis path,
+  .axis circle {
     stroke-width: 2;
     stroke: var(--c-base);
+    fill: transparent;
   }
 
   .gridlines line {

--- a/docs/app/styles/app.css
+++ b/docs/app/styles/app.css
@@ -576,3 +576,19 @@ dl {
     color: var(--c-line-0);
   }
 }
+
+blockquote {
+  background: var(--c-base-0);
+  margin: 2em 0;
+  padding: 1em;
+  font-weight: bold;
+  border-left: 3px solid var(--c-base-1);
+
+  p {
+    margin: 0;
+  }
+
+  p + p {
+    margin-top: 1em;
+  }
+}

--- a/docs/app/styles/app.css
+++ b/docs/app/styles/app.css
@@ -592,3 +592,22 @@ blockquote {
     margin-top: 1em;
   }
 }
+
+.flex-grid {
+  display: flex;
+  flex-direction: row;
+  height: 25px;
+  gap: 2px;
+
+  .diverging-scale-datum {
+    text-align: center;
+    color: var(--c-line-0);
+    width: 100%;
+
+    div {
+      height: 10px;
+      width: 100%;
+      margin-top: 5px;
+    }
+  }
+}

--- a/docs/app/styles/app.css
+++ b/docs/app/styles/app.css
@@ -467,6 +467,10 @@ dl {
   margin: auto;
   width: 100%;
 
+  .lineal-fluid {
+    width: 100%;
+  }
+
   &.with-left-axis {
     padding-left: 100px;
   }

--- a/docs/app/styles/app.css
+++ b/docs/app/styles/app.css
@@ -20,6 +20,8 @@
   --c-red-line: #d1675d;
   --c-blue: #94a9af;
   --c-blue-line: #346c8e;
+  --c-purple: #d483af;
+  --c-purple-line: #973e6e;
 }
 
 * {
@@ -301,6 +303,10 @@ pre code.hljs {
 .nominal-4 {
   color: var(--c-blue);
   fill: var(--c-blue);
+}
+.nominal-5 {
+  color: var(--c-purple);
+  fill: var(--c-purple);
 }
 
 .accent-green {
@@ -611,3 +617,39 @@ blockquote {
     }
   }
 }
+
+.waffle-chart {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 45px);
+  gap: 2px;
+
+  > div {
+    border: 1px solid black;
+    text-align: center;
+    font-size: 12px;
+    padding: 8px 0;
+    background: currentcolor;
+
+    span {
+      color: var(--c-line);
+    }
+  }
+}
+
+.fruit-list {
+  li::before {
+    content: var(--fruit);
+    padding-right: 1ch;
+  }
+
+  .fruit-apple {
+    --fruit: '🍎';
+  }
+  .fruit-banana {
+    --fruit: '🍌';
+  }
+  .fruit-grapes {
+    --fruit: '🍇';
+  }
+}
+

--- a/docs/app/styles/app.css
+++ b/docs/app/styles/app.css
@@ -468,6 +468,15 @@ dl {
   opacity: 0.5;
 }
 
+.demo-chart {
+  margin: auto;
+  width: 100%;
+
+  .lineal-fluid {
+    width: 100%;
+  }
+}
+
 .demo-chart-with-axes {
   padding: 50px;
   margin: auto;
@@ -653,3 +662,37 @@ blockquote {
   }
 }
 
+.relative-bars {
+  position: relative;
+  height: 30px;
+
+  .bar {
+    position: absolute;
+    top: 0;
+    color: var(--c-line);
+    background: var(--c-red);
+    border: 1px solid var(--c-red-line);
+    text-align: center;
+    padding: 5px 0;
+  }
+}
+
+.relative-points {
+  position: relative;
+  height: 30px;
+
+  .point {
+    position: absolute;
+    top: 0;
+    left: -15px;
+    padding: 15px 0;
+    width: 30px;
+    line-height: 0;
+    border-radius: 100%;
+    color: var(--c-line);
+    background: var(--c-green);
+    border: 1px solid var(--c-green-line);
+    box-sizing: content-box;
+    text-align: center;
+  }
+}

--- a/docs/docs/concepts/accessors.md
+++ b/docs/docs/concepts/accessors.md
@@ -1,0 +1,6 @@
+---
+title: Accessors
+order: 4
+---
+
+# Accessors

--- a/docs/docs/concepts/interactors.md
+++ b/docs/docs/concepts/interactors.md
@@ -1,0 +1,6 @@
+---
+title: Interactors
+order: 5
+---
+
+# Interactors

--- a/docs/docs/concepts/marks.md
+++ b/docs/docs/concepts/marks.md
@@ -1,0 +1,6 @@
+---
+title: Marks
+order: 2
+---
+
+# Marks

--- a/docs/docs/concepts/scales.md
+++ b/docs/docs/concepts/scales.md
@@ -210,9 +210,89 @@ Lineal has a class and a helper for almost all D3 Scales.
 </div>
 ```
 
-> ScaleTime and ScaleUtc
+### Time
 
-> ScaleDiverging, ScaleDivergingPow, ScaleDivergingLog, ScaleDivergingSqrt, ScaleDivergingSymlog
+```hbs preview-template
+<ScaleDemo
+  @scale={{scale-time domain=(array (date "01/01/2023") (date "06/01/2023"))}}
+  @data={{generate-linear-dates 21 start="01/01/2023" step=7}}
+/>
+```
+
+### UTC
+
+```hbs preview-template
+<ScaleDemo
+  @scale={{scale-utc domain=(array (date "01/01/2023") (date "01/07/2023"))}}
+  @data={{generate-linear-dates 21 start="01/01/2023" step=0.25}} />
+```
+
+### Diverging
+
+```hbs preview-template
+{{! The color-interpolator helper is NOT in Lineal, it's here as an example }}
+<DivergingScaleDemo
+  @data={{generate-linear 21 step=5 start=-50}}
+  @scale={{scale-diverging
+    domain=(array -50 0 50)
+    range=(color-interpolator 'interpolateRdBu')
+  }}
+/>
+```
+
+### Diverging Power
+
+```hbs preview-template
+{{! The color-interpolator helper is NOT in Lineal, it's here as an example }}
+<DivergingScaleDemo
+  @data={{generate-linear 21 step=5 start=-50}}
+  @scale={{scale-diverging-pow
+    domain=(array -50 0 50)
+    range=(color-interpolator 'interpolateRdBu')
+    exponent=3
+  }}
+/>
+```
+
+### Diverging Log
+
+```hbs preview-template
+{{! The color-interpolator helper is NOT in Lineal, it's here as an example }}
+<DivergingScaleDemo
+  @data={{generate-linear 21 step=50 start=0}}
+  @scale={{scale-diverging-log
+    domain=(array 1 250 1000)
+    range=(color-interpolator 'interpolateRdBu')
+    base=10
+  }}
+/>
+```
+
+### Diverging Square Root
+
+```hbs preview-template
+{{! The color-interpolator helper is NOT in Lineal, it's here as an example }}
+<DivergingScaleDemo
+  @data={{generate-linear 21 step=10 start=-100}}
+  @scale={{scale-diverging-sqrt
+    domain=(array -100 0 100)
+    range=(color-interpolator 'interpolateRdBu')
+  }}
+/>
+```
+
+### Diverging Symmetric Logarithmic
+
+```hbs preview-template
+{{! The color-interpolator helper is NOT in Lineal, it's here as an example }}
+<DivergingScaleDemo
+  @data={{generate-linear 21 step=10 start=-100}}
+  @scale={{scale-diverging-symlog
+    domain=(array -100 0 100)
+    range=(color-interpolator 'interpolateRdBu')
+  }}
+/>
+```
 
 > ScaleQuantize
 

--- a/docs/docs/concepts/scales.md
+++ b/docs/docs/concepts/scales.md
@@ -1,0 +1,50 @@
+---
+title: Scales
+order: 1
+---
+
+# Scales
+
+Ultimately, every data visualization maps the data to be visualized to a visual mark. Those visual marks (especially in SVG) are specified with properties like `x`, and `height`, and `r`, the values of which are their own data. So in other words, at the heart of a data visualization is a process of mapping data to...different data.
+
+Scales map **domain** data to **range** data. Or put another way, scales map data space to visual space.
+
+```js
+import { ScaleLinear } from '@lineal-viz/lineal/scale';
+
+// Our dataset is for birth years. We know the minimum is 1900 and the maximum
+// is 2023.
+const domain = [1900, 2023];
+
+// We are going to plot these birth years on a chart that we know is 800px
+// wide, plus we want to leave 30px of padding on either side.
+const range = [30, 770];
+
+// Scales are always constructed with a hash of parameters, this is for
+// the most straight forward compatibility with handlebars helpers.
+const scale = new ScaleLinear({ domain, range });
+
+// Now we can map a birth year to a pixel value. (well, really an anything
+// value, but presumably it's a pixel value to be used in a template)
+const x = scale.compute(1984); // 535.37
+```
+
+Since this is Ember, and Lineal has a template-first design philosophy, scales are all also available as helpers.
+
+```hbs 
+{{#let (scale-linear domain='1900..2023' range='30..770') as |scale|}}
+  <dl>
+    <dt>X</dt> <dd>{{scale.compute 1984}}</dd>
+    {{!-- Or if you're on a version of Ember < 4.5 --}}
+    <dt>X</dt> <dd>{{scale-fn-compute 1984}}</dd>
+  </dl>
+{{/let}}
+```
+
+## Similarity with D3 Scales
+
+## Specifying domains and ranges with Bounds
+
+## Types of scales
+
+## Further reading

--- a/docs/docs/concepts/scales.md
+++ b/docs/docs/concepts/scales.md
@@ -129,12 +129,102 @@ Presented in an imperative form like this doesn't get the whole effect across, b
 
 ## Types of scales
 
+Lineal has a class and a helper for almost all D3 Scales.
+
+### Linear
+
 ```hbs preview-template
 <ScaleDemo
   @scale={{scale-linear domain=".."}}
   @data={{generate-linear 21 step=5 start=0}}
 />
 ```
+
+### Power
+
+```hbs preview-template
+<ScaleDemo
+  @scale={{scale-pow domain=".." exponent=2}}
+  @data={{generate-linear 21 step=5 start=0}}
+/>
+```
+
+### Logarithmic
+
+```hbs preview-template
+<ScaleDemo
+  @scale={{scale-log domain=".." base=10}}
+  @data={{generate-linear 21 step=5 start=1}}
+/>
+```
+
+### Square Root
+
+```hbs preview-template
+<ScaleDemo
+  @scale={{scale-sqrt domain=".."}}
+  @data={{generate-linear 21 step=5 start=0}}
+/>
+```
+
+### Symmetric Logarithmic
+
+```hbs preview-template
+<ScaleDemo
+  @scale={{scale-symlog domain=".."}}
+  @data={{generate-linear 21 step=5 start=-50}}
+/>
+```
+
+### Radial
+
+```hbs preview-template
+<div class='demo-chart-with-axes'>
+  <Lineal::Fluid as |width|>
+    <svg width='100%' height='300px' style='overflow:visible'>
+      <g transform='translate({{div width 2}},150)'>
+        {{#let
+          (scale-radial domain='..' range=(array 40 (div (min width 300) 1.5)))
+          as |scale|
+        }}
+          {{#if scale.isValid}}
+            <g class='axis'>
+              {{#each scale.ticks as |tick|}}
+                <circle
+                  r={{scale.compute tick}}
+                ></circle>
+              {{/each}}
+            </g>
+          {{/if}}
+          <Lineal::Points
+            @data={{generate-linear 21 step=5 start=0}}
+            @x='x'
+            @xScale={{scale}}
+            @y={{0}}
+            @size={{3}}
+          />
+        {{/let}}
+      </g>
+    </svg>
+  </Lineal::Fluid>
+</div>
+```
+
+> ScaleTime and ScaleUtc
+
+> ScaleDiverging, ScaleDivergingPow, ScaleDivergingLog, ScaleDivergingSqrt, ScaleDivergingSymlog
+
+> ScaleQuantize
+
+> ScaleQuantile
+
+> ScaleThreshold
+
+> ScaleOrdinal
+
+> ScaleBand
+
+> ScalePoint
 
 ## CSS Range
 

--- a/docs/docs/concepts/scales.md
+++ b/docs/docs/concepts/scales.md
@@ -43,8 +43,99 @@ Since this is Ember, and Lineal has a template-first design philosophy, scales a
 
 ## Similarity with D3 Scales
 
+If you have used [D3](https://d3js.org/), this probably all looks familiar. Lineal scales are built on D3 scales, reshaped to be more ergonomic for Ember usage. The key differences are:
+
+1. Lineal scales are classes while D3 scales are function generators.
+2. Lineal takes all arguments in a hash to the constructor while D3 scales use a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface).
+
+```js
+const data = [1, 2, 3, 5, 8];
+
+// Using D3 scales
+const d3Scale = d3.scalePow()
+  .domain([0, 10])
+  .range([0, 250])
+  .exponent(3);
+
+console.log(data.map(d => d3Scale(d))); // [0.25, 2, 6.75, 31.25, 128]
+
+// Using Lineal scales
+const linealScale = new ScalePow({
+  domain: [0, 10],
+  range: [0, 250],
+  exponent: 3,
+});
+
+console.log(data.map(d => linealScale.compute(d))); // [0.25, 2, 6.75, 31.25, 128]
+```
+
+These changes are rather minor, but by treating scales as objects with tracked properties, they become much easier to use in a declarative, Ember-idiomatic, way.
+
+Lineal also introduces a new concept to scales called Bounds. Bounds are utility objects for modeling the min and max of a value range. Importantly, they can be passed around even if the min or max of the range is indeterminate. This too helps Lineal users write declarative code.
+
 ## Specifying domains and ranges with Bounds
 
+First and foremost, Bounds can parse ranges from strings. This typically done transparently as part of declaring a scale (in fact one of the snippets above alreaady showed this).
+
+```js
+const scale = new ScaleLinear({
+  domain: [0, 10],
+  range: '0..100', // Gets parsed as [0, 100]
+});
+
+console.log(scale.compute(3)) // 30
+```
+
+The immediate benefit of this feature is a nice experience when using scales in templates. The `array` helper can be used to construct static arrays in templates, but it's just a bit of friction that can be smoothed over.
+
+```hbs
+{{#let (scale-linear domain=(array 0 10) range="0..100") as |scale|}}
+  {{scale.compute 3}} {{! 30 }}
+{{/let}}
+```
+
+The feature that makes Bounds especially useful when constructing declarative templates and reusable components is creating **unqualified** Bounds. A Bounds is unqualified when the min or max is indeterminate. A scale that has an unqualified Bounds for its domain or range cannot be used to compute a value until the Bounds are qualified, but being able to declare a Bounds decoupled from specifying a min or max makes decoupling data from visualization easier.
+
+```js
+const data = [ 1, 1, 2, 3, 5, 8, 13 ];
+
+const fixed = new ScaleLinear({
+  domain: [0, 10],
+  range: [0, 100],
+});
+
+// Note that 130 is beyond the range because 13 is beyond the domain
+console.log(data.map(d => fixed.compute(d))); // [ 10, 10, 20, 30, 50, 80, 130 ]
+
+const dynamic = new ScaleLinear({
+  domain: '0..', // min is 0, max is undefined
+  range: '0..100', // shorthand for [0, 100]
+});
+
+// Until the dynamic scale is qualified, attempting to compute will error
+dynamic.compute(5) // Error: Bounds have not been qualified!
+
+// A Bounds can be qualified using a dataset and an accessor
+dynamic.domain.qualify(data, d => d);
+
+// The min, which was specified, will be preserved
+console.log(dynamic.domain.bounds) // [0, 13]
+
+// And now the scale can be used like normal
+console.log(data.map(d => dynamic.compute(d))); // [7.7, 7.7, 15.4, 23.0, 38.5, 61.5, 100]
+```
+
+Presented in an imperative form like this doesn't get the whole effect across, but the Marks concept documentation will have more examples where scales won't have to be qualified manually.
+
 ## Types of scales
+
+```hbs preview-template
+<ScaleDemo
+  @scale={{scale-linear domain=".."}}
+  @data={{generate-linear 21 step=5 start=0}}
+/>
+```
+
+## CSS Range
 
 ## Further reading

--- a/docs/docs/concepts/scales.md
+++ b/docs/docs/concepts/scales.md
@@ -344,4 +344,41 @@ Lineal has a class and a helper for almost all D3 Scales.
 {{/let}}
 ```
 
+### Band
+
+```hbs preview-template
+<div class='demo-chart relative-bars'>
+  <Lineal::Fluid as |width|>
+    {{#let (array 'A' 'B' 'C' 'D') as |data|}}
+      {{#let (scale-band domain=data range=(array 0 width) padding=0.1) as |scale|}}
+        {{#each data as |d|}}
+          <div class='bar' {{style
+            transform=(concat 'translateX(' (scale.compute d) 'px)')
+            width=(concat scale.bandwidth 'px')
+          }}>{{d}}</div>
+        {{/each}}
+      {{/let}}
+    {{/let}}
+  </Lineal::Fluid>
+</div>
+```
+
+### Point
+
+```hbs preview-template
+<div class='demo-chart relative-points'>
+  <Lineal::Fluid as |width|>
+    {{#let (array 'A' 'B' 'C' 'D') as |data|}}
+      {{#let (scale-point domain=data range=(array 0 width) padding=0.5) as |scale|}}
+        {{#each data as |d|}}
+          <div class='point' {{style
+            transform=(concat 'translateX(' (scale.compute d) 'px)')
+          }}>{{d}}</div>
+        {{/each}}
+      {{/let}}
+    {{/let}}
+  </Lineal::Fluid>
+</div>
+```
+
 ## Further reading

--- a/docs/docs/concepts/scales.md
+++ b/docs/docs/concepts/scales.md
@@ -127,6 +127,10 @@ console.log(data.map(d => dynamic.compute(d))); // [7.7, 7.7, 15.4, 23.0, 38.5, 
 
 Presented in an imperative form like this doesn't get the whole effect across, but the Marks concept documentation will have more examples where scales won't have to be qualified manually.
 
+## CSS Range
+
+TBW
+
 ## Types of scales
 
 Lineal has a class and a helper for almost all D3 Scales.
@@ -294,18 +298,50 @@ Lineal has a class and a helper for almost all D3 Scales.
 />
 ```
 
-> ScaleQuantize
+### Quantize
 
-> ScaleQuantile
+```hbs preview-template
+<PartitioningScaleDemo
+  @data={{generate-normal 100 stddev=2 sort=true}}
+  @scale={{scale-quantize domain='..' range=(css-range 'nominal') count=4}}
+/>
+```
 
-> ScaleThreshold
+### Quantile
 
-> ScaleOrdinal
+```hbs preview-template
+{{#let (generate-normal 100 stddev=2 sort=true) as |data|}}
+  <PartitioningScaleDemo
+    @data={{data}}
+    @scale={{scale-quantile domain=(map-by 'y' data) range=(css-range 'nominal') count=4}}
+  />
+{{/let}}
+```
 
-> ScaleBand
+### Threshold
 
-> ScalePoint
+```hbs preview-template
+<PartitioningScaleDemo
+  @data={{generate-normal 100 mean=75 stddev=8 sort=true}}
+  @scale={{scale-threshold domain=(array 60 70 80 90) range=(css-range 'nominal')}}
+/>
+```
 
-## CSS Range
+### Ordinal
+
+```hbs preview-template
+{{#let
+  (scale-ordinal
+    domain=(array 'apple' 'grapes' 'banana')
+    range=(array 'fruit-apple' 'fruit-grapes' 'fruit-banana')
+  ) as |scale|
+}}
+  <ol class='fruit-list'>
+    {{#each (array 'apple' 'grapes' 'apple' 'apple' 'banana' 'banana' 'grapes') as |fruit|}}
+      <li class='{{scale.compute fruit}}'>{{fruit}}</li>
+    {{/each}}
+  </ol>
+{{/let}}
+```
 
 ## Further reading

--- a/docs/docs/concepts/scales.md
+++ b/docs/docs/concepts/scales.md
@@ -129,7 +129,25 @@ Presented in an imperative form like this doesn't get the whole effect across, b
 
 ## CSS Range
 
-TBW
+It is common when visualizing data to encode discrete characteristics. This could be a color within a predefined set for an ordinal color scale, or a pattern for a partitioned map, or iconography or whatever other stylistic motifs. Typically, this is done using a scale with a discrete range (e.g., Theshold or Ordinal) to map a data value to a presentational value (color hex or class name). Lineal wants to use the platform as much as possible while also respecting the separation of concerns among document structure, behavior, and styles.
+
+For this reason, it is a best practice to map data to discrete CSS class names so that CSS can be in control of setting styles as much as possible. Lineal has a `CSSRange` class and `css-range` helper for making this as easy as possible.
+
+```js
+const range = new CSSRange('blues');
+const classes = range.spread(3);
+console.log(classes);
+// [
+//   'blues blues-1 blues-3-1',
+//   'blues blues-2 blues-3-2',
+//   'blues blues-3 blues-3-3'
+// ]
+
+const scale = new ScaleOrdinal({ range, domain: ['A', 'B', 'C', 'D'] });
+console.log(scale.compute('B')); // 'blues blues-2 blues-4-2'
+// Note that range.spread gets called internally in the ScaleOrdinal class with
+// the appropriate count based on the length of the scale's domain.
+```
 
 ## Types of scales
 

--- a/docs/docs/concepts/visual-elements.md
+++ b/docs/docs/concepts/visual-elements.md
@@ -1,0 +1,6 @@
+---
+title: Visual Elements
+order: 3
+---
+
+# Visual Elements

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,6 +33,7 @@
     "@lineal-viz/lineal": "*",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "d3-scale-chromatic": "^3.0.0",
     "ember-auto-import": "^2.4.0",
     "ember-cli": "~4.9.0",
     "ember-cli-app-version": "^5.0.0",

--- a/lineal-viz/src/components/lineal/points/index.ts
+++ b/lineal-viz/src/components/lineal/points/index.ts
@@ -50,12 +50,20 @@ export default class Points extends Component<PointsArgs> {
   }
 
   @cached get xScale() {
+    if (typeof this.args.x === 'number' && this.args.xScale == null) {
+      return new ScaleIdentity({ range: this.args.x });
+    }
+
     const scale = this.args.xScale || new ScaleLinear();
     qualifyScale(this, scale, this.x, 'x');
     return scale;
   }
 
   @cached get yScale() {
+    if (typeof this.args.y === 'number' && this.args.yScale == null) {
+      return new ScaleIdentity({ range: this.args.y });
+    }
+
     const scale = this.args.yScale || new ScaleLinear();
     qualifyScale(this, scale, this.y, 'y');
     return scale;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5808,7 +5808,7 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
 
-"d3-interpolate@1.2.0 - 3":
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
@@ -5819,6 +5819,14 @@ cyclist@^1.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.0.1.tgz#f09dec0aaffd770b7995f1a399152bf93052321e"
   integrity sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==
+
+d3-scale-chromatic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
 
 d3-scale@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Concept docs will be used to broadly introduce the different pieces of Lineal. The goal is to show some code while explaining context and philosophy that led to design decisions.

Other forms of documentation will include:

1. Tutorials
2. A gallery of examples
3. API reference docs