### PR TITLE
Scale getter refactor

### DIFF
--- a/.changeset/good-books-beg.md
+++ b/.changeset/good-books-beg.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Add static number support for Line and Area x and y encodings.

--- a/lineal-viz/src/components/lineal/area/index.ts
+++ b/lineal-viz/src/components/lineal/area/index.ts
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { scheduleOnce } from '@ember/runloop';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { cached } from '@glimmer/tracking';
 import { area, CurveFactory } from 'd3-shape';
-import { extent } from 'd3-array';
 import { Scale, ScaleLinear } from '../../../scale';
 import { Accessor, Encoding } from '../../../encoding';
-import Bounds from '../../../bounds';
 import { curveFor, CurveArgs } from '../../../utils/curves';
-import { qualifyScale } from '../../../utils/mark-utils';
+import { scaleFrom, qualifyScale } from '../../../utils/mark-utils';
 
 export interface AreaArgs {
   data: any[];
@@ -40,13 +36,13 @@ export default class Area extends Component<AreaArgs> {
   }
 
   @cached get xScale() {
-    const scale = this.args.xScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.x, this.args.xScale) || new ScaleLinear();
     qualifyScale(this, scale, this.x, 'x');
     return scale;
   }
 
   @cached get yScale() {
-    const scale = this.args.yScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.y, this.args.yScale) || new ScaleLinear();
     qualifyScale(this, scale, this.y, 'y');
     return scale;
   }

--- a/lineal-viz/src/components/lineal/bars/index.ts
+++ b/lineal-viz/src/components/lineal/bars/index.ts
@@ -4,11 +4,10 @@
  */
 
 import Component from '@glimmer/component';
-import { tracked, cached } from '@glimmer/tracking';
+import { cached } from '@glimmer/tracking';
 import { Accessor, Encoding } from '../../../encoding';
-import { Scale, ScaleLinear, ScaleOrdinal, ScaleSqrt, ScaleIdentity } from '../../../scale';
-import CSSRange from '../../../css-range';
-import { qualifyScale } from '../../../utils/mark-utils';
+import { Scale, ScaleLinear } from '../../../scale';
+import { qualifyScale, scaleFrom } from '../../../utils/mark-utils';
 
 export interface BarsArgs {
   data: any[];
@@ -48,41 +47,25 @@ export default class Bars extends Component<BarsArgs> {
   }
 
   @cached get xScale() {
-    if (typeof this.args.x === 'number' && this.args.xScale == null) {
-      return new ScaleIdentity({ range: this.args.x });
-    }
-
-    const scale = this.args.xScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.x, this.args.xScale) || new ScaleLinear();
     qualifyScale(this, scale, this.x, 'x');
     return scale;
   }
 
   @cached get yScale() {
-    if (typeof this.args.y === 'number' && this.args.yScale == null) {
-      return new ScaleIdentity({ range: this.args.y });
-    }
-
-    const scale = this.args.yScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.y, this.args.yScale) || new ScaleLinear();
     qualifyScale(this, scale, this.y, 'y');
     return scale;
   }
 
   @cached get widthScale() {
-    if (typeof this.args.width === 'number' && this.args.widthScale == null) {
-      return new ScaleIdentity({ range: this.args.width });
-    }
-
-    const scale = this.args.widthScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.width, this.args.widthScale) || new ScaleLinear();
     qualifyScale(this, scale, this.width, 'width');
     return scale;
   }
 
   @cached get heightScale() {
-    if (typeof this.args.height === 'number' && this.args.heightScale == null) {
-      return new ScaleIdentity({ range: this.args.height });
-    }
-
-    const scale = this.args.heightScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.height, this.args.heightScale) || new ScaleLinear();
     qualifyScale(this, scale, this.height, 'height');
     return scale;
   }

--- a/lineal-viz/src/components/lineal/line/index.ts
+++ b/lineal-viz/src/components/lineal/line/index.ts
@@ -9,7 +9,7 @@ import { line } from 'd3-shape';
 import { Scale, ScaleLinear } from '../../../scale';
 import { Accessor, Encoding } from '../../../encoding';
 import { curveFor, CurveArgs } from '../../../utils/curves';
-import { qualifyScale } from '../../../utils/mark-utils';
+import { scaleFrom, qualifyScale } from '../../../utils/mark-utils';
 
 export interface LineArgs {
   data: any[];
@@ -31,13 +31,13 @@ export default class Line extends Component<LineArgs> {
   }
 
   @cached get xScale() {
-    const scale = this.args.xScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.x, this.args.xScale) || new ScaleLinear();
     qualifyScale(this, scale, this.x, 'x');
     return scale;
   }
 
   @cached get yScale() {
-    const scale = this.args.yScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.y, this.args.yScale) || new ScaleLinear();
     qualifyScale(this, scale, this.y, 'y');
     return scale;
   }

--- a/lineal-viz/src/components/lineal/points/index.ts
+++ b/lineal-viz/src/components/lineal/points/index.ts
@@ -4,11 +4,11 @@
  */
 
 import Component from '@glimmer/component';
-import { tracked, cached } from '@glimmer/tracking';
+import { cached } from '@glimmer/tracking';
 import { Accessor, Encoding } from '../../../encoding';
 import { Scale, ScaleLinear, ScaleOrdinal, ScaleSqrt, ScaleIdentity } from '../../../scale';
 import CSSRange from '../../../css-range';
-import { qualifyScale } from '../../../utils/mark-utils';
+import { scaleFrom, qualifyScale } from '../../../utils/mark-utils';
 
 export interface PointsArgs {
   data: any[];
@@ -50,31 +50,19 @@ export default class Points extends Component<PointsArgs> {
   }
 
   @cached get xScale() {
-    if (typeof this.args.x === 'number' && this.args.xScale == null) {
-      return new ScaleIdentity({ range: this.args.x });
-    }
-
-    const scale = this.args.xScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.x, this.args.xScale) || new ScaleLinear();
     qualifyScale(this, scale, this.x, 'x');
     return scale;
   }
 
   @cached get yScale() {
-    if (typeof this.args.y === 'number' && this.args.yScale == null) {
-      return new ScaleIdentity({ range: this.args.y });
-    }
-
-    const scale = this.args.yScale || new ScaleLinear();
+    const scale = scaleFrom(this.args.y, this.args.yScale) || new ScaleLinear();
     qualifyScale(this, scale, this.y, 'y');
     return scale;
   }
 
   @cached get sizeScale() {
-    if (typeof this.args.size === 'number' && this.args.sizeScale == null) {
-      return new ScaleIdentity({ range: this.args.size });
-    }
-
-    const scale = this.args.sizeScale || new ScaleSqrt();
+    const scale = scaleFrom(this.args.size, this.args.sizeScale) || new ScaleSqrt();
     qualifyScale(this, scale, this.size, 'size');
     return scale;
   }


### PR DESCRIPTION
This is mostly just a refactor, but it does add a smol feature (really just filling out some missing behavior)

1. Lines and Areas can now accept numbers as `x` and `y` encodings