### PR TITLE
New tickCount and lineCount args to match d3 tickArguments

### DIFF
--- a/lineal-viz/src/components/lineal/axis/index.ts
+++ b/lineal-viz/src/components/lineal/axis/index.ts
@@ -29,6 +29,7 @@ export enum Direction {
 export interface AxisArgs {
   scale: Scale;
   orientation: Orientation;
+  tickCount?: number;
   tickValues?: any[];
   tickFormat?: (t: any) => string;
   tickSize?: number;
@@ -64,8 +65,9 @@ const TEXT_ANCHOR = {
 };
 
 export default class Axis extends Component<AxisArgs> {
-  // TODO: Implement tickArguments for d3-axis parity, but maybe not the same signature.
-  //tickArguments = [];
+  @cached get tickCount() {
+    return this.args.tickCount ?? null;
+  }
 
   @cached get tickValues() {
     return this.args.tickValues ?? null;
@@ -147,8 +149,13 @@ export default class Axis extends Component<AxisArgs> {
 
   @cached get values() {
     if (this.tickValues) return this.tickValues;
-    if (this.args.scale.d3Scale.ticks) return this.args.scale.d3Scale.ticks();
-    return this.args.scale.d3Scale.domain();
+
+    const scale = this.args.scale?.d3Scale;
+    if (scale?.ticks) {
+      return this.tickCount != null ? scale.ticks(this.tickCount) : scale.ticks();
+    }
+
+    return scale?.domain();
   }
 
   @cached get format() {

--- a/lineal-viz/src/components/lineal/gridlines/index.ts
+++ b/lineal-viz/src/components/lineal/gridlines/index.ts
@@ -16,6 +16,7 @@ export interface GridlinesArgs {
   scale: Scale;
   direction: Direction;
   length: number;
+  lineCount?: number;
   lineValues?: any[];
   offset?: number;
 }
@@ -23,7 +24,13 @@ export interface GridlinesArgs {
 const DEFAULT_OFFSET = typeof window !== 'undefined' && window.devicePixelRatio > 1 ? 0 : 0.5;
 
 export default class Gridlines extends Component<GridlinesArgs> {
-  @tracked lineValues = this.args.lineValues || null;
+  @cached get lineValues() {
+    return this.args.lineValues ?? null;
+  }
+
+  @cached get lineCount() {
+    return this.args.lineCount ?? null;
+  }
 
   @cached get offset() {
     return this.args.offset ?? DEFAULT_OFFSET;
@@ -31,8 +38,13 @@ export default class Gridlines extends Component<GridlinesArgs> {
 
   @cached get values() {
     if (this.lineValues) return this.lineValues;
-    if (this.args.scale.d3Scale.ticks) return this.args.scale.d3Scale.ticks();
-    return this.args.scale.d3Scale.domain();
+
+    const scale = this.args.scale?.d3Scale;
+    if (scale?.ticks) {
+      return this.lineCount != null ? scale.ticks(this.lineCount) : scale.ticks();
+    }
+
+    return scale?.domain();
   }
 
   @cached get position() {

--- a/test-app/app/templates/application.hbs
+++ b/test-app/app/templates/application.hbs
@@ -5,7 +5,7 @@
 <p>Axes</p>
 {{#let (scale-pow range='15..785' domain='0..10' exponent='2') as |scale|}}
   <svg class='no-overflow' width='800' height='30'>
-    <Lineal::Axis @scale={{scale}} @orientation='bottom' />
+    <Lineal::Axis @scale={{scale}} @tickCount={{3}} @orientation='bottom' />
   </svg>
   <svg class='no-overflow' width='800' height='30'>
     <Lineal::Axis @scale={{scale}} @orientation='top' as |tick|>
@@ -102,7 +102,7 @@
           <Lineal::Axis
             @scale={{yScale}}
             @orientation='left'
-            @tickValues={{array 20000000 100000000 200000000 280000000}}
+            @tickCount={{100}}
           />
           <Lineal::Axis
             @scale={{xScale}}
@@ -111,7 +111,7 @@
           />
           <Lineal::Gridlines
             @scale={{yScale}}
-            @lineValues={{array 20000000 100000000 200000000 280000000}}
+            @lineCount={{100}}
             @direction='horizontal'
             @length={{width}}
             stroke-dasharray='5 5'

--- a/test-app/tests/integration/components/lineal/axis-test.ts
+++ b/test-app/tests/integration/components/lineal/axis-test.ts
@@ -106,6 +106,33 @@ module('Integration | Component | Lineal::Axis', function (hooks) {
     )
   );
 
+  test('The tickCount arg is used to influence the number of ticks', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const tickCount = 3;
+    this.setProperties({ scale, tickCount });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Axis
+          @scale={{this.scale}}
+          @orientation="bottom"
+          @tickCount={{this.tickCount}}
+          @offset={{0}} />
+      </svg>
+    `);
+
+    assert.dom('.axis line').exists({ count: tickCount });
+
+    this.set('tickCount', 8);
+
+    assert
+      .dom('.axis line')
+      .exists(
+        { count: 11 },
+        'when the specified tickCount is not appropriate for the domain/scale, a better number is used'
+      );
+  });
+
   test('The tickValues arg is used to manually specify rendered ticks', async function (assert) {
     const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
     const tickValues = [0, 0.5, 1.5, 3, 5, 7.5];

--- a/test-app/tests/integration/components/lineal/gridlines-test.ts
+++ b/test-app/tests/integration/components/lineal/gridlines-test.ts
@@ -47,6 +47,34 @@ module('Integration | Component | Lineal::Gridlines', function (hooks) {
     );
   });
 
+  test('The lineCount arg is used to influence the number of lines', async function (assert) {
+    const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
+    const lineCount = 3;
+    this.setProperties({ scale, lineCount });
+
+    await render(hbs`
+      <svg>
+        <Lineal::Gridlines
+          @scale={{this.scale}}
+          @lineCount={{this.lineCount}}
+          @direction="vertical"
+          @length={{100}}
+          @offset={{0}} />
+      </svg>
+    `);
+
+    assert.dom('.gridlines line').exists({ count: lineCount });
+
+    this.set('lineCount', 8);
+
+    assert
+      .dom('.gridlines line')
+      .exists(
+        { count: 11 },
+        'when the specified lineCount is not appropriate for the domain/scale, a better number is used'
+      );
+  });
+
   test('The lineValues arg is used to manually specify gridline positions', async function (assert) {
     const scale = new ScaleLinear({ range: '0..100', domain: '0..10' });
     const lineValues = [0, 10, 20, 30, 50, 80];


### PR DESCRIPTION
These values get passed into the scale.ticks function, which returns a number of ticks approximately equal to the provided value. If the number would result in weird tick values, [d3-scale prioritizes nice numbers over exact tick counts](https://github.com/d3/d3-scale#continuous_ticks).

**Setting tickCount to 4**

This results in 6 ticks because that's a nicer subdivision of the domain 0-10 on a linear scale.

<img width="809" alt="image" src="https://user-images.githubusercontent.com/174740/228657869-033bed15-6e46-4a00-8460-340a1e498432.png">

**Setting tickCount to 100**

It's a bit of an eyesore, but you get (approximately) what you ask for.

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/174740/228658163-bdc51792-2b3b-44c0-bd3f-2f5a297be0c3.png">

If you really really need precisely the number of ticks you wish for, you have to do the math yourself and use `@tickValues`.