### PR TITLE
Stack Helpers

### DIFF
--- a/.changeset/metal-pens-nail.md
+++ b/.changeset/metal-pens-nail.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': minor
+---
+
+Stack helpers (for creating stack transforms within templates)

--- a/lineal-viz/package.json
+++ b/lineal-viz/package.json
@@ -109,6 +109,9 @@
       "./helpers/scale-threshold.js": "./dist/_app_/helpers/scale-threshold.js",
       "./helpers/scale-time.js": "./dist/_app_/helpers/scale-time.js",
       "./helpers/scale-utc.js": "./dist/_app_/helpers/scale-utc.js",
+      "./helpers/stack-h.js": "./dist/_app_/helpers/stack-h.js",
+      "./helpers/stack-v.js": "./dist/_app_/helpers/stack-v.js",
+      "./helpers/stack.js": "./dist/_app_/helpers/stack.js",
       "./modifiers/interactor-cartesian-horizontal.js": "./dist/_app_/modifiers/interactor-cartesian-horizontal.js"
     }
   },

--- a/lineal-viz/src/helpers/stack-h.ts
+++ b/lineal-viz/src/helpers/stack-h.ts
@@ -1,0 +1,6 @@
+import { helper } from '@ember/component/helper';
+import Stack, { StackConfig } from '../transforms/stack';
+
+export default helper(
+  ([], hash: StackConfig) => new Stack(Object.assign({}, hash, { direction: 'horizontal' }))
+);

--- a/lineal-viz/src/helpers/stack-v.ts
+++ b/lineal-viz/src/helpers/stack-v.ts
@@ -1,0 +1,6 @@
+import { helper } from '@ember/component/helper';
+import Stack, { StackConfig } from '../transforms/stack';
+
+export default helper(
+  ([], hash: StackConfig) => new Stack(Object.assign({}, hash, { direction: 'vertical' }))
+);

--- a/lineal-viz/src/helpers/stack.ts
+++ b/lineal-viz/src/helpers/stack.ts
@@ -1,0 +1,4 @@
+import { helper } from '@ember/component/helper';
+import Stack, { StackConfig } from '../transforms/stack';
+
+export default helper(([], hash: StackConfig) => new Stack(hash));

--- a/test-app/app/templates/stacks.hbs
+++ b/test-app/app/templates/stacks.hbs
@@ -127,3 +127,90 @@
     ></rect>
   {{/let}}
 </svg>
+
+<h2>Stacked Area 3</h2>
+<button type='button' {{on 'click' this.appendTestData}}>Append</button>
+<p>{{this.stacked._categories}}</p>
+<svg height='300' width='800' class='no-overflow m-100'>
+  {{! (stack-y data=this.paddedFrequencyByDay x='hour' y='value' z='day') }}
+  {{#let
+    (scale-linear range='0..800' domain='0..30')
+    (scale-linear range='300..0' domain='0..')
+    (stack-v data=this.newData order='ascending' x='hour' y='value' z='day')
+    as |xScale yScale stacked|
+  }}
+    {{#if (and xScale.isValid yScale.isValid)}}
+      <Lineal::Axis
+        @scale={{yScale}}
+        @orientation='left'
+        @includeDomain={{false}}
+      />
+      <Lineal::Axis
+        @scale={{xScale}}
+        @orientation='bottom'
+        transform='translate(0,300)'
+      />
+      <Lineal::Gridlines
+        @scale={{yScale}}
+        @direction='horizontal'
+        @length='800'
+        stroke-dasharray='5 5'
+      />
+    {{/if}}
+    <Lineal::Area
+      @data={{stacked.data}}
+      @x='x'
+      @y='y'
+      @xScale={{xScale}}
+      @yScale={{yScale}}
+      @colorScale='ordinal'
+    />
+    {{#if (and xScale.isValid yScale.isValid)}}
+      {{#if this.activeStackSlice}}
+        <g class='interaction-overlay'>
+          <line
+            stroke='red'
+            stroke-width='2'
+            x1={{xScale.compute this.activeStackSlice.datum.datum.hour}}
+            x2={{xScale.compute this.activeStackSlice.datum.datum.hour}}
+            y1='0'
+            y2='300'
+          ></line>
+          {{#each
+            (stacked.stack (map-by 'datum' this.activeStackSlice.data))
+            as |d|
+          }}
+            <circle
+              cx={{xScale.compute d.x}}
+              cy={{yScale.compute d.y}}
+              r='5'
+              fill='black'
+            ></circle>
+            <text
+              x={{xScale.compute d.x}}
+              y={{yScale.compute d.y}}
+              dx='10'
+              text-anchor='start'
+            >{{d.key}}</text>
+          {{/each}}
+        </g>
+      {{/if}}
+    {{/if}}
+    <rect
+      x='0'
+      y='0'
+      width='800'
+      height='300'
+      tabindex='0'
+      fill='transparent'
+      class='interactor'
+      {{interactor-cartesian-horizontal
+        data=stacked.dataIn
+        xScale=xScale
+        x='hour'
+        y='value'
+        onSeek=this.updateActiveStackDatum
+      }}
+    ></rect>
+  {{/let}}
+</svg>

--- a/test-app/tests/integration/helpers/stack-h-test.ts
+++ b/test-app/tests/integration/helpers/stack-h-test.ts
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import * as sinon from 'sinon';
+
+module('Integration | helpers | stack-h', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('stack-h creates a stack with a horizontal direction', async function (assert) {
+    const spy = sinon.spy();
+    this.setProperties({ spy });
+
+    await render(hbs`
+      {{#let (stack-h x='foo' y='bar' z='baz' data=(array)) as |stack|}}
+        {{spy this.spy stack}}
+      {{/let}}
+    `);
+
+    const stack = spy.getCall(0).args[0];
+    assert.strictEqual(stack.direction, 'horizontal');
+  });
+
+  test('stach-h will have a horizontal direction, even when a vertical direction is specified', async function (assert) {
+    const spy = sinon.spy();
+    this.setProperties({ spy });
+
+    await render(hbs`
+      {{#let (stack-h x='foo' y='bar' z='baz' data=(array) direction='vertical') as |stack|}}
+        {{spy this.spy stack}}
+      {{/let}}
+    `);
+
+    const stack = spy.getCall(0).args[0];
+    assert.strictEqual(stack.direction, 'horizontal');
+  });
+});

--- a/test-app/tests/integration/helpers/stack-v-test.ts
+++ b/test-app/tests/integration/helpers/stack-v-test.ts
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import * as sinon from 'sinon';
+
+module('Integration | helpers | stack-v', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('stack-h creates a stack with a vertical direction', async function (assert) {
+    const spy = sinon.spy();
+    this.setProperties({ spy });
+
+    await render(hbs`
+      {{#let (stack-v x='foo' y='bar' z='baz' data=(array)) as |stack|}}
+        {{spy this.spy stack}}
+      {{/let}}
+    `);
+
+    const stack = spy.getCall(0).args[0];
+    assert.strictEqual(stack.direction, 'vertical');
+  });
+
+  test('stach-h will have a vertical direction, even when a horizontal direction is specified', async function (assert) {
+    const spy = sinon.spy();
+    this.setProperties({ spy });
+
+    await render(hbs`
+      {{#let (stack-v x='foo' y='bar' z='baz' data=(array) direction='horizontal') as |stack|}}
+        {{spy this.spy stack}}
+      {{/let}}
+    `);
+
+    const stack = spy.getCall(0).args[0];
+    assert.strictEqual(stack.direction, 'vertical');
+  });
+});


### PR DESCRIPTION
Helper parity with the `Stack` transform class.

```js
const stack = new Stack({
  data: this.data,
  x: 'foo',
  y: 'bar',
  z: 'baz',
});
```

Can now be achieved in Handlebars with

```hbs
{{#let (stack data=this.data x='foo' y='bar' z='baz')}}
{{/let}}
```

Additionally, there are `stack-h` and `stack-v` helpers for ensuring horizontal and vertical stacking directions, respectively.