### PR TITLE
Fill holes in tables within the stack transform

### DIFF
--- a/.changeset/tender-pigs-kick.md
+++ b/.changeset/tender-pigs-kick.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Bug fix: fill holes in data sets when tabulating from records

--- a/lineal-viz/src/transforms/stack.ts
+++ b/lineal-viz/src/transforms/stack.ts
@@ -285,7 +285,7 @@ export default class Stack {
         ...categories.reduce((columns, category) => {
           // It is assumed that there is a single record per category, otherwise it would
           // mean there were duplicte records in the source data.
-          columns[category] = cell.accessor(records.get(category)?.[0] ?? {});
+          columns[category] = cell.accessor(records.get(category)?.[0] ?? {}) ?? 0;
           return columns;
         }, {}),
       });


### PR DESCRIPTION
When records are brackish, they would create tables with holes (cells with undefined values). This ensures that any otherwise undefined or null values are instead `0` for compatibility with D3 stack.