### PR TITLE
New stackedCategories getter for Stack

### DIFF
--- a/lineal-viz/src/transforms/stack.ts
+++ b/lineal-viz/src/transforms/stack.ts
@@ -413,4 +413,8 @@ export default class Stack {
       ? (stack as StackSeriesVertical[]).map(vMap)
       : (stack as StackSeriesHorizontal[]).map(hMap);
   };
+
+  get stackedCategories() {
+    return this.data.map((d) => d.key).reverse();
+  }
 }

--- a/test-app/tests/unit/transforms/stack-test.ts
+++ b/test-app/tests/unit/transforms/stack-test.ts
@@ -455,4 +455,26 @@ module('Unit | Transforms | Stack', function () {
       'The null value has been replaced with a 0'
     );
   });
+
+  test('The stackedCategories getter returns categories in the visual order data is stacked in', function (assert) {
+    const stack = new Stack({
+      data: TEST_DATA,
+      order: 'insideOut',
+      x: 'hour',
+      y: 'value',
+      z: 'day',
+    });
+
+    assert.deepEqual(
+      stack.categories,
+      ['Sunday', 'Monday', 'Tuesday'],
+      'categories are in input order'
+    );
+
+    assert.deepEqual(
+      stack.stackedCategories,
+      stack.data.map((d) => d.key).reverse(),
+      'stackedCategories are in visual stack order'
+    );
+  });
 });


### PR DESCRIPTION
This returns the categories for a stack in the visual stack order. This is useful for aligning tooltips or other elements with the visual alignment of the stacked visual mark(s).