### PR TITLE
Check the name of the class *and* instanceof 

### DIFF
--- a/.changeset/funny-cows-leave.md
+++ b/.changeset/funny-cows-leave.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+Bug fix: ScaleOrdinal wouldn't work with uglified bundles

--- a/lineal-viz/src/scale.ts
+++ b/lineal-viz/src/scale.ts
@@ -905,7 +905,7 @@ export class ScaleOrdinal implements Scale {
   @cached get d3Scale() {
     // TODO: Return to instanceof checks when https://github.com/ef4/ember-auto-import/pull/512 is released.
     const range: string[] =
-      this.range.constructor.name === 'CSSRange'
+      this.range.constructor.name === 'CSSRange' || this.range instanceof CSSRange
         ? (this.range as CSSRange).spread(this.domain.length)
         : (this.range as string[]);
     const scale = scales.scaleOrdinal(range).domain(this.domain);


### PR DESCRIPTION
The name check is required for tests, where instanceof won't work. The
instanceof check is required in production, where the name check won't
work, due to uglification.

Once again https://github.com/embroider-build/ember-auto-import/pull/512
is a thorn in my side.