### PR TITLE
borderRadius arg for bar marks

### DIFF
--- a/.changeset/dry-files-switch.md
+++ b/.changeset/dry-files-switch.md
@@ -1,0 +1,5 @@
+---
+'@lineal-viz/lineal': patch
+---
+
+@borderRadius args for Bars, VBars, and HBars marks

--- a/lineal-viz/src/components/lineal/bars/index.hbs
+++ b/lineal-viz/src/components/lineal/bars/index.hbs
@@ -2,7 +2,10 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#each this.bars as |b|}}
-  <rect x={{b.x}} y={{b.y}} width={{b.width}} height={{b.height}} ...attributes></rect>
+  {{#if b.d}}
+    <path d={{b.d}} ...attributes></path>
+  {{else}}
+    <rect x={{b.x}} y={{b.y}} width={{b.width}} height={{b.height}} ...attributes></rect>
+  {{/if}}
 {{/each}}

--- a/lineal-viz/src/components/lineal/bars/index.ts
+++ b/lineal-viz/src/components/lineal/bars/index.ts
@@ -8,6 +8,8 @@ import { cached } from '@glimmer/tracking';
 import { Accessor, Encoding } from '../../../encoding';
 import { Scale, ScaleLinear } from '../../../scale';
 import { qualifyScale, scaleFrom } from '../../../utils/mark-utils';
+import { cssFourPropParse } from '../../../utils/css-four-prop-parse';
+import { roundedRect } from '../../../utils/rounded-rect';
 
 export interface BarsArgs {
   data: any[];
@@ -19,6 +21,7 @@ export interface BarsArgs {
   yScale?: Scale;
   widthScale?: Scale;
   heightScale?: Scale;
+  borderRadius?: string;
 }
 
 export interface BarDatum {
@@ -27,6 +30,7 @@ export interface BarDatum {
   width: number;
   height: number;
   datum: any;
+  d?: string;
 }
 
 export default class Bars extends Component<BarsArgs> {
@@ -70,6 +74,10 @@ export default class Bars extends Component<BarsArgs> {
     return scale;
   }
 
+  @cached get borderRadius() {
+    if (this.args.borderRadius) return cssFourPropParse(this.args.borderRadius);
+  }
+
   @cached get bars(): BarDatum[] {
     if (
       !this.xScale.isValid ||
@@ -80,7 +88,7 @@ export default class Bars extends Component<BarsArgs> {
       return [];
     }
 
-    return this.args.data.map((d: any) => {
+    const bars = this.args.data.map((d: any) => {
       const bar: BarDatum = {
         x: this.xScale.compute(this.x.accessor(d)),
         y: this.yScale.compute(this.y.accessor(d)),
@@ -91,5 +99,22 @@ export default class Bars extends Component<BarsArgs> {
 
       return bar;
     });
+
+    const borderRadius = this.borderRadius;
+
+    if (borderRadius) {
+      const radii = {
+        topLeft: borderRadius.top,
+        topRight: borderRadius.right,
+        bottomRight: borderRadius.bottom,
+        bottomLeft: borderRadius.left,
+      };
+
+      bars.forEach((bar) => {
+        bar.d = roundedRect(bar, radii, true);
+      });
+    }
+
+    return bars;
   }
 }

--- a/lineal-viz/src/components/lineal/h-bars/index.hbs
+++ b/lineal-viz/src/components/lineal/h-bars/index.hbs
@@ -2,21 +2,24 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.isStacked}}
   <g>
     {{#each this.bars as |series|}}
       <g>
         {{#each series.bars as |b|}}
-          <rect
-            x={{b.x}}
-            y={{b.y}}
-            width={{b.width}}
-            height={{b.height}}
-            fill={{series.fill}}
-            class={{series.cssClass}}
-            ...attributes
-          ></rect>
+          {{#if b.d}}
+            <path d={{b.d}} fill={{series.fill}} class={{series.cssClass}} ...attributes></path>
+          {{else}}
+            <rect
+              x={{b.x}}
+              y={{b.y}}
+              width={{b.width}}
+              height={{b.height}}
+              fill={{series.fill}}
+              class={{series.cssClass}}
+              ...attributes
+            ></rect>
+          {{/if}}
         {{/each}}
       </g>
     {{/each}}
@@ -24,7 +27,11 @@
 {{else}}
   <g>
     {{#each this.bars as |b|}}
-      <rect x={{b.x}} y={{b.y}} width={{b.width}} height={{b.height}} ...attributes></rect>
+      {{#if b.d}}
+        <path d={{b.d}} ...attributes></path>
+      {{else}}
+        <rect x={{b.x}} y={{b.y}} width={{b.width}} height={{b.height}} ...attributes></rect>
+      {{/if}}
     {{/each}}
   </g>
 {{/if}}

--- a/lineal-viz/src/components/lineal/v-bars/index.hbs
+++ b/lineal-viz/src/components/lineal/v-bars/index.hbs
@@ -2,21 +2,24 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: MPL-2.0
 }}
-
 {{#if this.isStacked}}
   <g>
     {{#each this.bars as |series|}}
       <g>
         {{#each series.bars as |b|}}
-          <rect
-            x={{b.x}}
-            y={{b.y}}
-            width={{b.width}}
-            height={{b.height}}
-            fill={{series.fill}}
-            class={{series.cssClass}}
-            ...attributes
-          ></rect>
+          {{#if b.d}}
+            <path d={{b.d}} fill={{series.fill}} class={{series.cssClass}} ...attributes></path>
+          {{else}}
+            <rect
+              x={{b.x}}
+              y={{b.y}}
+              width={{b.width}}
+              height={{b.height}}
+              fill={{series.fill}}
+              class={{series.cssClass}}
+              ...attributes
+            ></rect>
+          {{/if}}
         {{/each}}
       </g>
     {{/each}}
@@ -24,7 +27,11 @@
 {{else}}
   <g>
     {{#each this.bars as |b|}}
-      <rect x={{b.x}} y={{b.y}} width={{b.width}} height={{b.height}} ...attributes></rect>
+      {{#if b.d}}
+        <path d={{b.d}} ...attributes></path>
+      {{else}}
+        <rect x={{b.x}} y={{b.y}} width={{b.width}} height={{b.height}} ...attributes></rect>
+      {{/if}}
     {{/each}}
   </g>
 {{/if}}

--- a/lineal-viz/src/components/lineal/v-bars/index.ts
+++ b/lineal-viz/src/components/lineal/v-bars/index.ts
@@ -10,6 +10,8 @@ import { Accessor, Encoding } from '../../../encoding';
 import { Scale, ScaleLinear, ScaleOrdinal } from '../../../scale';
 import CSSRange from '../../../css-range';
 import { qualifyScale, scaleFrom } from '../../../utils/mark-utils';
+import { cssFourPropParse } from '../../../utils/css-four-prop-parse';
+import { roundedRect } from '../../../utils/rounded-rect';
 import Stack from '../../../transforms/stack';
 
 export interface BarsArgs {
@@ -23,6 +25,7 @@ export interface BarsArgs {
   yScale?: Scale;
   widthScale?: Scale;
   colorScale?: Scale;
+  borderRadius?: string;
 }
 
 export interface BarDatum {
@@ -31,6 +34,7 @@ export interface BarDatum {
   width: number;
   height: number;
   datum: any;
+  d?: string;
 }
 
 export interface BarSeries {
@@ -133,13 +137,20 @@ export default class Bars extends Component<BarsArgs> {
     return this.colorScale instanceof Object && this.colorScale.range instanceof CSSRange;
   }
 
+  @cached get borderRadius() {
+    if (this.args.borderRadius) return cssFourPropParse(this.args.borderRadius);
+  }
+
   @cached get bars(): BarDatum[] | BarSeries[] {
     if (!this.xScale.isValid || !this.yScale.isValid || !this.widthScale.isValid) {
       return [];
     }
 
+    const borderRadius = this.borderRadius;
+
     if (this.isStacked) {
       return this.data.map((series) => {
+        const idx = series.visualOrder;
         const barSeries: BarSeries = {
           bars: series.map(
             (d: any): BarDatum => ({
@@ -151,6 +162,28 @@ export default class Bars extends Component<BarsArgs> {
             })
           ),
         };
+
+        if (borderRadius && (idx === 0 || idx === this.data.length - 1)) {
+          const radii = {
+            topLeft: borderRadius.top,
+            topRight: borderRadius.right,
+            bottomRight: borderRadius.bottom,
+            bottomLeft: borderRadius.left,
+          };
+
+          // When multi series, render top corners if first series,
+          // or the bottom coners if last series.
+          if (this.data.length > 1) {
+            Object.assign(
+              radii,
+              idx === 0 ? { topLeft: 0, topRight: 0 } : { bottomLeft: 0, bottomRight: 0 }
+            );
+          }
+
+          barSeries.bars.forEach((bar) => {
+            bar.d = roundedRect(bar, radii, true);
+          });
+        }
 
         if (this.colorScale) {
           const colorValue = this.colorScale.compute(series.key);
@@ -164,7 +197,7 @@ export default class Bars extends Component<BarsArgs> {
         return barSeries;
       });
     } else {
-      return this.args.data.map(
+      const bars = this.args.data.map(
         (d: any): BarDatum => ({
           x: this.xScale.compute(this.x.accessor(d)),
           y: this.yScale.compute(this.y.accessor(d)),
@@ -174,6 +207,21 @@ export default class Bars extends Component<BarsArgs> {
           datum: d,
         })
       );
+
+      if (borderRadius) {
+        const radii = {
+          topLeft: borderRadius.top,
+          topRight: borderRadius.right,
+          bottomRight: borderRadius.bottom,
+          bottomLeft: borderRadius.left,
+        };
+
+        bars.forEach((bar) => {
+          bar.d = roundedRect(bar, radii, true);
+        });
+      }
+
+      return bars;
     }
   }
 }

--- a/lineal-viz/src/utils/css-four-prop-parse.ts
+++ b/lineal-viz/src/utils/css-four-prop-parse.ts
@@ -1,0 +1,30 @@
+export type FourProp = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+const UNITLESS_PATTERN = /^\d+( \d+){0,3}$/;
+
+export function cssFourPropParse(str: string): FourProp {
+  if (!UNITLESS_PATTERN.test(str)) {
+    throw new Error('Cannot parse four prop string. Must be a unitless string of 1 to 4 numbers');
+  }
+
+  const parts = str.split(' ').map((p) => +p);
+
+  switch (parts.length) {
+    case 1:
+      return { top: parts[0], right: parts[0], bottom: parts[0], left: parts[0] };
+    case 2:
+      return { top: parts[0], right: parts[1], bottom: parts[0], left: parts[1] };
+    case 3:
+      return { top: parts[0], right: parts[1], bottom: parts[2], left: parts[1] };
+    case 4:
+      return { top: parts[0], right: parts[1], bottom: parts[2], left: parts[3] };
+    default:
+      // Inaccessible
+      throw new Error('Four prop string contained more than 4 parts');
+  }
+}

--- a/lineal-viz/src/utils/rounded-rect.ts
+++ b/lineal-viz/src/utils/rounded-rect.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface BorderRadius {
+  topLeft: number;
+  topRight: number;
+  bottomLeft: number;
+  bottomRight: number;
+}
+
+// Start drawing at x, y
+const move = (x: number, y: number) => `M ${x},${y}`;
+
+// Draw lines using y and x as deltas instead of coordinates
+const vLine = (y: number) => `v ${y}`;
+const hLine = (x: number) => `h ${x}`;
+
+// A clockwise-turning small arc with equal radii
+const arc = (r: number, hDir: number, vDir: number) => `a ${r},${r} 0 0 1 ${r * hDir},${r * vDir}`;
+
+/**
+ * A function that takes the bounding box of a rectangle along with all four
+ * border radii and generates a valid SVG path string with the correct lines
+ * and arcs.
+ *
+ * @param rect - The rectangle to round.
+ * @param radii - The four radii for the rectangle.
+ * @returns - A valid SVG path string (to use as a `d` attribute value)
+ */
+export function roundedRect(rect: Rect, radii: BorderRadius): string {
+  return [
+    move(rect.x, rect.y + radii.topLeft),
+    arc(radii.topLeft, 1, -1),
+    hLine(rect.width - radii.topLeft - radii.topRight),
+    arc(radii.topRight, 1, 1),
+    vLine(rect.height - radii.topRight - radii.bottomRight),
+    arc(radii.bottomRight, -1, 1),
+    hLine(-rect.width + radii.bottomRight + radii.bottomLeft),
+    arc(radii.bottomLeft, -1, -1),
+    vLine(-rect.height + radii.bottomLeft + radii.topLeft),
+    'Z',
+  ].join(' ');
+}

--- a/test-app/app/controllers/arcs.ts
+++ b/test-app/app/controllers/arcs.ts
@@ -5,9 +5,26 @@
 
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { roundedRect } from '@lineal-viz/lineal/utils/rounded-rect';
 
 export default class ArcsController extends Controller {
   @tracked activeDatum = null;
 
   logValue = (...args: any[]) => console.log(...args);
+
+  rrect = (rect: string, radii: string) => {
+    const [x, y, width, height] = rect.split(' ').map((d) => +d);
+    const [topLeft, topRight, bottomLeft, bottomRight] = radii
+      .split(' ')
+      .map((d) => +d);
+    return roundedRect(
+      { x: x ?? 0, y: y ?? 0, width: width ?? 0, height: height ?? 0 },
+      {
+        topLeft: topLeft ?? 0,
+        topRight: topRight ?? 0,
+        bottomLeft: bottomLeft ?? 0,
+        bottomRight: bottomRight ?? 0,
+      }
+    );
+  };
 }

--- a/test-app/app/controllers/arcs.ts
+++ b/test-app/app/controllers/arcs.ts
@@ -24,7 +24,8 @@ export default class ArcsController extends Controller {
         topRight: topRight ?? 0,
         bottomLeft: bottomLeft ?? 0,
         bottomRight: bottomRight ?? 0,
-      }
+      },
+      true
     );
   };
 }

--- a/test-app/app/controllers/stacks.ts
+++ b/test-app/app/controllers/stacks.ts
@@ -63,15 +63,15 @@ export default class StacksController extends Controller {
 
   get frequencyByDay() {
     return [
-      { day: 'Monday', hour: 9, value: -rand(1, 20) },
-      { day: 'Monday', hour: 10, value: -rand(1, 20) },
-      { day: 'Monday', hour: 11, value: -rand(1, 20) },
-      { day: 'Monday', hour: 12, value: -rand(1, 20) },
+      { day: 'Monday', hour: 9, value: rand(1, 20) },
+      { day: 'Monday', hour: 10, value: rand(1, 20) },
+      { day: 'Monday', hour: 11, value: rand(1, 20) },
+      { day: 'Monday', hour: 12, value: rand(1, 20) },
 
-      { day: 'Tuesday', hour: 11, value: -rand(1, 20) },
-      { day: 'Tuesday', hour: 12, value: -rand(1, 20) },
-      { day: 'Tuesday', hour: 14, value: -rand(1, 20) },
-      { day: 'Tuesday', hour: 18, value: -rand(1, 20) },
+      { day: 'Tuesday', hour: 11, value: rand(1, 20) },
+      { day: 'Tuesday', hour: 12, value: rand(1, 20) },
+      { day: 'Tuesday', hour: 14, value: rand(1, 20) },
+      { day: 'Tuesday', hour: 18, value: rand(1, 20) },
 
       { day: 'Wednesday', hour: 11, value: rand(1, 20) },
       { day: 'Wednesday', hour: 12, value: rand(1, 20) },
@@ -101,7 +101,7 @@ export default class StacksController extends Controller {
           freq.find((d) => d.day === day && d.hour === hour) || {
             day,
             hour,
-            value: ['Monday', 'Tuesday'].includes(day) ? -2 : 2,
+            value: 2,
           }
         );
       }

--- a/test-app/app/templates/arcs.hbs
+++ b/test-app/app/templates/arcs.hbs
@@ -4,47 +4,47 @@
 }}
 
 <h2>Arcs</h2>
-<svg width='800' height='200'>
-  <g transform='translate(400 100)'>
+<svg width="800" height="200">
+  <g transform="translate(400 100)">
     <Lineal::Arc
-      @startAngle='90d'
-      @endAngle='270d'
+      @startAngle="90d"
+      @endAngle="270d"
       @innerRadius={{50}}
       @outerRadius={{75}}
-      fill='pink'
+      fill="pink"
     />
   </g>
 </svg>
 
 <h2>Pie</h2>
-<svg width='400' height='400'>
-  <g transform='translate(200 200)'>
+<svg width="400" height="400">
+  <g transform="translate(200 200)">
     <Lineal::Arcs
       @data={{array (hash v=1) (hash v=10) (hash v=4)}}
-      @theta='v'
-      @colorScale='reds'
+      @theta="v"
+      @colorScale="reds"
       @outerRadius={{150}}
       @innerRadius={{100}}
-      @padAngle='1d'
+      @padAngle="1d"
     />
   </g>
 </svg>
 
 <h2>Pie 2</h2>
-<svg width='400' height='400'>
-  <g transform='translate(200 200)'>
+<svg width="400" height="400">
+  <g transform="translate(200 200)">
     <Lineal::Arcs
       @data={{array
-        (hash v=1 c='red')
-        (hash v=0 c='blue')
-        (hash v=10 c='red')
-        (hash v=4 c='fish')
+        (hash v=1 c="red")
+        (hash v=0 c="blue")
+        (hash v=10 c="red")
+        (hash v=4 c="fish")
       }}
-      @theta='v'
-      @startAngle='270d'
-      @endAngle='450d'
-      @color='c'
-      @colorScale='reds'
+      @theta="v"
+      @startAngle="270d"
+      @endAngle="450d"
+      @color="c"
+      @colorScale="reds"
       as |pie|
     >
       {{#each pie as |slice|}}
@@ -53,17 +53,17 @@
           @endAngle={{slice.endAngle}}
           @outerRadius={{150}}
           @innerRadius={{100}}
-          stroke='white'
-          stroke-width='2'
+          stroke="white"
+          stroke-width="2"
           opacity={{if
             this.activeDatum
             (if (eq slice.data this.activeDatum) 1 0.3)
             1
           }}
           class={{slice.cssClass}}
-          {{on 'mouseover' (fn (mut this.activeDatum) slice.data)}}
-          {{on 'click' (fn this.logValue slice)}}
-          {{on 'mouseout' (fn (mut this.activeDatum) null)}}
+          {{on "mouseover" (fn (mut this.activeDatum) slice.data)}}
+          {{on "click" (fn this.logValue slice)}}
+          {{on "mouseout" (fn (mut this.activeDatum) null)}}
         />
       {{/each}}
     </Lineal::Arcs>

--- a/test-app/app/templates/arcs.hbs
+++ b/test-app/app/templates/arcs.hbs
@@ -69,3 +69,9 @@
     </Lineal::Arcs>
   </g>
 </svg>
+
+<h2>Rounded corners</h2>
+<svg width="500" height="500" style="overflow: visible">
+  <path d={{this.rrect "0 0 100 100" "15 15 15 15"}} />
+  <path d={{this.rrect "150 0 75 50" "40 40 40 40"}} />
+</svg>

--- a/test-app/app/templates/arcs.hbs
+++ b/test-app/app/templates/arcs.hbs
@@ -73,5 +73,5 @@
 <h2>Rounded corners</h2>
 <svg width="500" height="500" style="overflow: visible">
   <path d={{this.rrect "0 0 100 100" "15 15 15 15"}} />
-  <path d={{this.rrect "150 0 75 50" "40 40 40 40"}} />
+  <path d={{this.rrect "150 0 75 50" "50 50 40 40"}} />
 </svg>

--- a/test-app/app/templates/points-bands.hbs
+++ b/test-app/app/templates/points-bands.hbs
@@ -87,6 +87,7 @@
       @xScale={{xScale}}
       @yScale={{yScale}}
       @heightScale={{hScale}}
+      @borderRadius="40 40 0 0"
     />
   {{/let}}
 </svg>

--- a/test-app/app/templates/points-bands.hbs
+++ b/test-app/app/templates/points-bands.hbs
@@ -4,48 +4,48 @@
 }}
 
 <h2>Points</h2>
-<svg height='300' width='800' class='no-overflow m-100'>
+<svg height="300" width="800" class="no-overflow m-100">
   {{#let
-    (scale-linear domain='0..23' range='0..800')
-    (scale-point domain=this.daysOfWeek range='0..300')
+    (scale-linear domain="0..23" range="0..800")
+    (scale-point domain=this.daysOfWeek range="0..300")
     as |xScale yScale|
   }}
     {{#if (and xScale.isValid yScale.isValid)}}
       <Lineal::Gridlines
         @scale={{yScale}}
-        @direction='horizontal'
-        @length='800'
+        @direction="horizontal"
+        @length="800"
       />
       <Lineal::Gridlines
         @scale={{xScale}}
-        @direction='vertical'
-        @length='300'
+        @direction="vertical"
+        @length="300"
       />
     {{/if}}
-    <rect x='0' y='0' width='800' height='300' class='svg-border'></rect>
+    <rect x="0" y="0" width="800" height="300" class="svg-border"></rect>
     <Lineal::Points
       @data={{this.frequencyByDay}}
       @renderCircles={{true}}
-      @x='hour'
-      @y='day'
-      @size='value'
-      @color='day'
+      @x="hour"
+      @y="day"
+      @size="value"
+      @color="day"
       @xScale={{xScale}}
       @yScale={{yScale}}
-      @sizeScale={{scale-sqrt domain='1..25' range='5..25'}}
+      @sizeScale={{scale-sqrt domain="1..25" range="5..25"}}
       @colorScale={{scale-ordinal
         domain=this.daysOfWeek
-        range=(css-range 'ordinal')
+        range=(css-range "ordinal")
       }}
-      class='svg-border-gray'
+      class="svg-border-gray"
       as |points|
     >
       {{#each points as |p|}}
         <text
-          class='plot-label'
+          class="plot-label"
           x={{p.x}}
           y={{p.y}}
-          dy={{if (lt p.size 10) '-15'}}
+          dy={{if (lt p.size 10) "-15"}}
         >{{fmt p.datum.value}}</text>
       {{/each}}
     </Lineal::Points>
@@ -53,36 +53,36 @@
 </svg>
 
 <h2>Bars</h2>
-<svg height='300' width='800' class='no-overflow m-100'>
+<svg height="300" width="800" class="no-overflow m-100">
   {{#let
-    (scale-band domain=this.categories range='0..800' padding=0.1)
-    (scale-linear range='0..300' domain='0..')
-    (scale-linear range='300..0' domain='0..')
+    (scale-band domain=this.categories range="0..800" padding=0.1)
+    (scale-linear range="0..300" domain="0..")
+    (scale-linear range="300..0" domain="0..")
     as |xScale hScale yScale|
   }}
     {{#if (and xScale.isValid yScale.isValid)}}
       <Lineal::Axis
         @scale={{yScale}}
-        @orientation='left'
+        @orientation="left"
         @includeDomain={{false}}
       />
       <Lineal::Axis
         @scale={{xScale}}
-        @orientation='bottom'
-        transform='translate(0,{{hScale.range.max}})'
+        @orientation="bottom"
+        transform="translate(0,{{hScale.range.max}})"
       />
       <Lineal::Gridlines
         @scale={{yScale}}
-        @direction='horizontal'
-        @length='800'
-        stroke-dasharray='5 5'
+        @direction="horizontal"
+        @length="800"
+        stroke-dasharray="5 5"
       />
     {{/if}}
     <Lineal::Bars
       @data={{this.ageDemo}}
-      @x='bracket'
-      @y='value'
-      @height='value'
+      @x="bracket"
+      @y="value"
+      @height="value"
       @width={{xScale.bandwidth}}
       @xScale={{xScale}}
       @yScale={{yScale}}

--- a/test-app/app/templates/stacks.hbs
+++ b/test-app/app/templates/stacks.hbs
@@ -306,6 +306,7 @@
       @xScale={{xScale}}
       @yScale={{yScale}}
       @colorScale='energy-mix'
+      @borderRadius="10"
     />
   {{/let}}
 </svg>

--- a/test-app/tests/integration/components/lineal/h-bars-test.ts
+++ b/test-app/tests/integration/components/lineal/h-bars-test.ts
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { ScaleLinear, ScaleBand } from '@lineal-viz/lineal/scale';
+import { roundedRect } from '@lineal-viz/lineal/utils/rounded-rect';
 
 const getAttrs = (el: Element, ...attrs: string[]) =>
   attrs.map((attr) => el.getAttribute(attr));
@@ -139,5 +140,84 @@ module('Integration | Component | Lineal::HBars', function (hooks) {
     assert.dom('g g rect.reds-3-1').exists({ count: 4 });
     assert.dom('g g rect.reds-3-2').exists({ count: 4 });
     assert.dom('g g rect.reds-3-3').exists({ count: 4 });
+  });
+
+  test('When @borderRadius is provided, paths of rounded rectangles are rendered instead of rects', async function (assert) {
+    const xScale = new ScaleLinear({ domain: '0..', range: '0..100' });
+    const yScale = new ScaleBand({
+      domain: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+      range: '0..100',
+      padding: 0.1,
+    });
+
+    this.setProperties({ data, xScale, yScale });
+
+    await render(hbs`
+      <svg class="test-svg">
+        <Lineal::HBars
+          @data={{this.data}}
+          @x="bar"
+          @y="foo"
+          @x0={{0}}
+          @height={{this.yScale.bandwidth}}
+          @xScale={{this.xScale}}
+          @yScale={{this.yScale}}
+          @borderRadius='5 8'
+        />
+      </svg>
+    `);
+
+    assert.strictEqual(findAll('path').length, data.length);
+    assert.deepEqual(
+      findAll('path').map((el: Element) => el.getAttribute('d')),
+      data.map((d) =>
+        roundedRect(
+          {
+            x: xScale.compute(d.bar),
+            y: yScale.compute(d.foo) ?? 0,
+            height: yScale.bandwidth,
+            width: xScale.compute(d.bar) - xScale.compute(0),
+          },
+          { topLeft: 5, topRight: 8, bottomRight: 5, bottomLeft: 8 },
+          true
+        )
+      )
+    );
+  });
+
+  test('When @borderRadius is provided and data is stacked, visually top rects are half-rounded paths and visually bottom rects are half-rounded paths', async function (assert) {
+    // By half-rounding the top rects and half-rounding the bottom rects, the complete slice of data is fully rounded
+    const xScale = new ScaleLinear({ domain: '0..', range: '0..100' });
+    const yScale = new ScaleBand({
+      domain: ['A', 'B', 'C', 'D'],
+      range: '0..100',
+      padding: 0.1,
+    });
+
+    this.setProperties({ stackableData, xScale, yScale });
+
+    await render(hbs`
+      <svg class="test-svg">
+        <Lineal::HBars
+          @data={{this.stackableData}}
+          @x="bar"
+          @y="foo"
+          @color="cat"
+          @height={{this.yScale.bandwidth}}
+          @xScale={{this.xScale}}
+          @yScale={{this.yScale}}
+          @colorScale="reds"
+          @borderRadius='5 8'
+        />
+      </svg>
+    `);
+
+    assert.dom('g g').exists({ count: 3 });
+    assert.dom('g g path.reds-3-1').exists({ count: 4 });
+    assert.dom('g g rect.reds-3-2').exists({ count: 4 });
+    assert.dom('g g path.reds-3-3').exists({ count: 4 });
+    assert.dom('g g rect.reds-3-1').exists({ count: 0 });
+    assert.dom('g g path.reds-3-2').exists({ count: 0 });
+    assert.dom('g g rect.reds-3-3').exists({ count: 0 });
   });
 });

--- a/test-app/tests/unit/transforms/stack-test.ts
+++ b/test-app/tests/unit/transforms/stack-test.ts
@@ -34,7 +34,7 @@ interface Datum {
 const tag = (
   arr: StackDatumVertical[],
   { key, index }: SeriesStd
-): StackSeriesVertical => Object.assign(arr, { key, index });
+): StackSeriesVertical => Object.assign(arr, { key, index, visualOrder: 0 });
 
 const convert = (data: SeriesStd[]) =>
   data.map((series) => tag(series.map(verticalStackMap), series));
@@ -126,7 +126,7 @@ module('Unit | Transforms | Stack', function () {
           { y0: 0, y1: 1, y: 1, x: 10, data: stack.table[10] },
           { y0: 0, y1: 2, y: 2, x: 11, data: stack.table[11] },
         ],
-        { key: 'Sunday', index: 0 }
+        { key: 'Sunday', index: 0, visualOrder: 0 }
       ),
       'Each stack series has y0, y1, and x properties in addition to the full corresponding table record'
     );
@@ -148,10 +148,13 @@ module('Unit | Transforms | Stack', function () {
           { y0: 1, y1: 12, y: 12, x: 10, data: stack.table[10] },
           { y0: 2, y1: 14, y: 14, x: 11, data: stack.table[11] },
         ],
-        { key: 'Monday', index: 1 }
+        { key: 'Monday', index: 1, visualOrder: 0 }
       ),
       'Each series in a stack stacks on the previous series'
     );
+
+    assert.strictEqual(stack.data[0]?.visualOrder, 0);
+    assert.strictEqual(stack.data[1]?.visualOrder, 1);
   });
 
   test('When the direction is horizontal, series stack on x values', function (assert) {
@@ -197,7 +200,7 @@ module('Unit | Transforms | Stack', function () {
           { x0: 1, x1: 12, x: 12, y: 10, data: stack.table[10] },
           { x0: 2, x1: 14, x: 14, y: 11, data: stack.table[11] },
         ],
-        { key: 'Monday', index: 1 }
+        { key: 'Monday', index: 1, visualOrder: 1 }
       ),
       'Each series in a stack stacks on the previous series'
     );

--- a/test-app/tests/unit/utils/css-four-prop-parse-test.ts
+++ b/test-app/tests/unit/utils/css-four-prop-parse-test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module } from 'qunit';
+import {
+  cssFourPropParse,
+  FourProp,
+} from '@lineal-viz/lineal/utils/css-four-prop-parse';
+import tableTest from '../../utils/table-test';
+
+module('Unit | cssFourPropParse', function () {
+  tableTest<string, string>(
+    [
+      {
+        name: 'When one value is provided, the returned FourProps has four equal values',
+        input: '10',
+        output: '10 10 10 10',
+      },
+      {
+        name: 'When two values are provided, the returned FourProps has mirrored top/bottom left/right values',
+        input: '10 20',
+        output: '10 20 10 20',
+      },
+      {
+        name: 'When three values are provided, the returned FourProps has mirrored left/right values',
+        input: '10 20 30',
+        output: '10 20 30 20',
+      },
+      {
+        name: 'When four values are provided, the returned FourProps has four independent values',
+        input: '10 20 30 40',
+        output: '10 20 30 40',
+      },
+      {
+        name: 'When five values are provided, an error is thrown',
+        input: '10 20 30 40 50',
+        output: null,
+      },
+      {
+        name: 'When units are attached to values, an error is thrown',
+        input: '10px 20%',
+        output: null,
+      },
+    ],
+    1,
+    function (t, assert) {
+      const fmt = (props: FourProp) =>
+        `${props.top} ${props.right} ${props.bottom} ${props.left}`;
+
+      if (t.output === null) {
+        assert.throws(() => cssFourPropParse(t.input));
+      } else {
+        assert.strictEqual(fmt(cssFourPropParse(t.input)), t.output);
+      }
+    }
+  );
+});

--- a/test-app/tests/unit/utils/rounded-rect-test.ts
+++ b/test-app/tests/unit/utils/rounded-rect-test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { module, test } from 'qunit';
+import { module } from 'qunit';
 import { roundedRect } from '@lineal-viz/lineal/utils/rounded-rect';
 import tableTest from '../../utils/table-test';
 
@@ -84,6 +84,45 @@ module('Unit | roundedRect', function () {
       } else {
         assert.strictEqual(roundedRect(...t.input), t.output);
       }
+    }
+  );
+
+  tableTest<[Rect, BorderRadius], string>(
+    [
+      {
+        name: 'The safe directive does nothing when radii are 0',
+        input: [b(0, 0, 100, 100), r(0, 0, 0, 0)],
+        output:
+          'M 0,0 a 0,0 0 0 1 0,0 h 100 a 0,0 0 0 1 0,0 v 100 a 0,0 0 0 1 0,0 h -100 a 0,0 0 0 1 0,0 v -100 Z',
+      },
+      {
+        name: 'The safe directive does nothing when radii total less than width/height',
+        input: [b(0, 0, 100, 100), r(8, 8, 8, 8)],
+        output:
+          'M 0,8 a 8,8 0 0 1 8,-8 h 84 a 8,8 0 0 1 8,8 v 84 a 8,8 0 0 1 -8,8 h -84 a 8,8 0 0 1 -8,-8 v -84 Z',
+      },
+      {
+        name: 'The safe directive shrinks radii only when necessary',
+        input: [b(0, 0, 100, 100), r(60, 60, 60, 60)],
+        output:
+          'M 0,50 a 50,50 0 0 1 50,-50 h 0 a 50,50 0 0 1 50,50 v 0 a 50,50 0 0 1 -50,50 h 0 a 50,50 0 0 1 -50,-50 v 0 Z',
+      },
+      {
+        name: 'The safe directive shrinks x/y radii for each corner independently',
+        input: [b(0, 0, 100, 30), r(40, 40, 0, 0)],
+        output:
+          'M 0,30 a 40,30 0 0 1 40,-30 h 20 a 40,30 0 0 1 40,30 v 0 a 0,0 0 0 1 0,0 h -100 a 0,0 0 0 1 0,0 v 0 Z',
+      },
+      {
+        name: 'The safe directive shrinks radii proportionally when the width/height is too small',
+        input: [b(0, 0, 100, 100), r(90, 30, 90, 30)],
+        output:
+          'M 0,75 a 75,75 0 0 1 75,-75 h 0 a 25,25 0 0 1 25,25 v 0 a 75,75 0 0 1 -75,75 h 0 a 25,25 0 0 1 -25,-25 v 0 Z',
+      },
+    ],
+    1,
+    function (t, assert) {
+      assert.strictEqual(roundedRect.apply(null, [...t.input, true]), t.output);
     }
   );
 });

--- a/test-app/tests/unit/utils/rounded-rect-test.ts
+++ b/test-app/tests/unit/utils/rounded-rect-test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { module, test } from 'qunit';
+import { roundedRect } from '@lineal-viz/lineal/utils/rounded-rect';
+import tableTest from '../../utils/table-test';
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface BorderRadius {
+  topLeft: number;
+  topRight: number;
+  bottomLeft: number;
+  bottomRight: number;
+}
+
+const b = (x: number, y: number, width: number, height: number) => ({
+  x,
+  y,
+  width,
+  height,
+});
+
+const r = (
+  topLeft: number,
+  topRight: number,
+  bottomRight: number,
+  bottomLeft: number
+) => ({ topLeft, topRight, bottomRight, bottomLeft });
+
+module('Unit | roundedRect', function () {
+  tableTest<[Rect, BorderRadius], string>(
+    [
+      {
+        name: 'A rectangle with no border radii creates a path with arcs with sharp angles',
+        input: [b(0, 0, 100, 100), r(0, 0, 0, 0)],
+        output:
+          'M 0,0 a 0,0 0 0 1 0,0 h 100 a 0,0 0 0 1 0,0 v 100 a 0,0 0 0 1 0,0 h -100 a 0,0 0 0 1 0,0 v -100 Z',
+      },
+      {
+        name: 'A rectangle with even border radii creates uniform corners, accounting for the corner size in drawn lines',
+        input: [b(0, 0, 100, 100), r(8, 8, 8, 8)],
+        output:
+          'M 0,8 a 8,8 0 0 1 8,-8 h 84 a 8,8 0 0 1 8,8 v 84 a 8,8 0 0 1 -8,8 h -84 a 8,8 0 0 1 -8,-8 v -84 Z',
+      },
+      {
+        name: 'A rectangle with uneven border radii creates uneven corners but respects the initial height and width',
+        input: [b(0, 0, 100, 100), r(8, 22, 9, 0)],
+        output:
+          'M 0,8 a 8,8 0 0 1 8,-8 h 70 a 22,22 0 0 1 22,22 v 69 a 9,9 0 0 1 -9,9 h -91 a 0,0 0 0 1 0,0 v -92 Z',
+      },
+      {
+        name: 'An irregular rectangle with even border radii respects the initial height and width',
+        input: [b(0, 0, 300, 50), r(10, 10, 10, 10)],
+        output:
+          'M 0,10 a 10,10 0 0 1 10,-10 h 280 a 10,10 0 0 1 10,10 v 30 a 10,10 0 0 1 -10,10 h -280 a 10,10 0 0 1 -10,-10 v -30 Z',
+      },
+      {
+        name: 'A rectangle positioned offset from the 0,0 origin draws a correct rectangle using delta instructions h, v, and a',
+        input: [b(100, 200, 300, 50), r(10, 10, 10, 10)],
+        output:
+          'M 100,210 a 10,10 0 0 1 10,-10 h 280 a 10,10 0 0 1 10,10 v 30 a 10,10 0 0 1 -10,10 h -280 a 10,10 0 0 1 -10,-10 v -30 Z',
+      },
+      {
+        name: 'A rectangle with radii that sum larger than the dimensions of the provided rectangle faithfully creates a path despite the expected rendering glitches',
+        input: [b(0, 0, 75, 50), r(40, 40, 40, 40)],
+        output:
+          'M 0,40 a 40,40 0 0 1 40,-40 h -5 a 40,40 0 0 1 40,40 v -30 a 40,40 0 0 1 -40,40 h 5 a 40,40 0 0 1 -40,-40 v 30 Z',
+      },
+    ],
+    1,
+    function (t, assert) {
+      if (t.output === null) {
+        assert.throws(() => {
+          roundedRect(...t.input);
+        });
+      } else {
+        assert.strictEqual(roundedRect(...t.input), t.output);
+      }
+    }
+  );
+});


### PR DESCRIPTION
This adds a `@borderRadius` arg to `Lineal::Bars`, `Lineal::VBars`, and `Lineal::HBars`. The arg accepts a 1/2/3/4 part string in a unitless style based on padding/margin/border-radius in CSS.

Notably, SVG doesn't simply support rounded corners like HTML does, so when this arg is provided, the mark components will draw appropriate `path` elements with `d` attrs that use arc and line directives.

This arg is also stack aware, so when borderRadius is provided when bars are stacked, only the top and bottom rects will get corner radii (so the full stacked bar has a rounded effect).

The idea here is to make it easy to achieve a common visual aesthetic without closing the door to people who'd prefer to achieve this with masks or css or `rx`/`ry` properties.