### PR TITLE
Set publishConfig.access to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "pnpm": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org"
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## Summary
- Adds `"access": "public"` to `publishConfig` in `package.json`

## Why
Scoped packages (`@hashicorp/*`) default to **private** on first publish. Setting `access: public` in `publishConfig` makes intent explicit and means contributors and CI don't need to remember to pass `--access public` on the initial publish of `@hashicorp/lineal`.

No-op for subsequent publishes (which already inherit the existing access level), but useful as documentation and a safety net.