### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -18,6 +18,8 @@ jobs:
   should-run-release-plan-prepare:
     name: Should we run release-plan prepare?
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should-prepare: ${{ steps.should-prepare.outputs.should-prepare }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/hashicorp/lineal/security/code-scanning/14](https://github.com/hashicorp/lineal/security/code-scanning/14)

Add an explicit `permissions` block for the `should-run-release-plan-prepare` job so it does not inherit potentially broad default token scopes.

Best minimal fix (without changing functionality): in `.github/workflows/plan-release.yml`, under job `should-run-release-plan-prepare` (after `runs-on`), add:

- `permissions:`
  - `contents: read`

This grants only read access to repository contents for that job, which is the least-privilege baseline likely needed for determining whether to prepare a release. The `create-prepare-release-pr` job already has explicit write scopes and should remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
